### PR TITLE
preserve filename and metadata fields on backup/restore

### DIFF
--- a/backup/moodle2/backup_equella_stepslib.php
+++ b/backup/moodle2/backup_equella_stepslib.php
@@ -18,7 +18,7 @@ class backup_equella_activity_structure_step extends backup_activity_structure_s
     protected function define_structure() {
         $equella = new backup_nested_element('equella',
                 array('id'),
-                array('course','name','intro','introformat','timecreated','timemodified','url','mimetype','popup','activation','uuid','version','path','attachmentuuid','ltisalt')
+                array('course','name','intro','introformat','timecreated','timemodified','url','mimetype','popup','activation','uuid','version','path','attachmentuuid','ltisalt','filename','metadata')
         );
         $equella->set_source_table('equella', array('id' => backup::VAR_ACTIVITYID));
         $equella->annotate_files('mod_equella', 'intro', null);


### PR DESCRIPTION
Most obvious for instances of the module where the icon used in Moodle on the course page is derived from the filename rather than the mimetype field, e.g. MP3. The generic icon gets used instead on the restored resources.