### PR TITLE
added privacy provider, including lti launch details

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-03-13 Nick Charles
+
+	GDPR compliance
+
 2020-03-11 Nick Charles
 
 	Replace starburst icons with open sourced versions

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,90 @@
+<?php
+ 
+namespace mod_equella\privacy;
+
+use core_privacy\local\metadata\collection;
+use core_privacy\local\request\approved_contextlist;
+use core_privacy\local\request\approved_userlist;
+use core_privacy\local\request\context;
+use core_privacy\local\request\contextlist;
+use core_privacy\local\request\userlist;
+
+defined('MOODLE_INTERNAL') || die();
+
+class provider implements
+        \core_privacy\local\metadata\provider,
+        \core_privacy\local\request\core_userlist_provider,
+        \core_privacy\local\request\plugin\provider {
+
+    /**
+     * Returns meta data about this system.
+     *
+     * @param   collection $collection The initialised collection to add items to.
+     * @return  collection     A listing of user data stored through this system.
+     */
+    public static function get_metadata(collection $collection) : collection {
+ 
+            $collection->add_external_location_link('lti_client', [
+                'userid' => 'privacy:metadata:lti_client:userid',
+                'roles' => 'privacy:metadata:lti_client:roles',
+                'fullname' => 'privacy:metadata:lti_client:fullname',
+                'givenname' => 'privacy:metadata:lti_client:givenname',
+                'familyname' => 'privacy:metadata:lti_client:familyname',
+                'email' => 'privacy:metadata:lti_client:email',
+    
+            ], 'privacy:metadata:lti_client');
+     
+        return $collection;
+
+    }
+
+    /**
+     * Get the list of contexts that contain user information for the specified user.
+     *
+     * @param   int $userid The user to search.
+     * @return  contextlist   $contextlist  The contextlist containing the list of contexts used in this plugin.
+     */
+    public static function get_contexts_for_userid(int $userid) : contextlist {
+        return new contextlist();
+    }
+
+    /**
+     * Get the list of users who have data within a context.
+     *
+     * @param   userlist    $userlist   The userlist containing the list of users who have data in this context/plugin combination.
+     */
+    public static function get_users_in_context(userlist $userlist) {
+    }
+
+    /**
+     * Export all user data for the specified user, in the specified contexts.
+     *
+     * @param   approved_contextlist $contextlist The approved contexts to export information for.
+     */
+    public static function export_user_data(approved_contextlist $contextlist) {
+    }
+
+    /**
+     * Delete all data for all users in the specified context.
+     *
+     * @param   context $context The specific context to delete data for.
+     */
+    public static function delete_data_for_all_users_in_context(\context $context) {
+    }
+
+    /**
+     * Delete all user data for the specified user, in the specified contexts.
+     *
+     * @param   approved_contextlist $contextlist The approved contexts and user information to delete information for.
+     */
+    public static function delete_data_for_user(approved_contextlist $contextlist) {
+    }
+
+    /**
+     * Delete multiple users within a single context.
+     *
+     * @param   approved_userlist       $userlist The approved context and user information to delete information for.
+     */
+    public static function delete_data_for_users(approved_userlist $userlist) {
+    }
+}

--- a/lang/en/equella.php
+++ b/lang/en/equella.php
@@ -169,7 +169,7 @@ $string['webserviceerror'] = '{$a}';
 ////////////////////////////////////////////////////////
 // GDPR compliance
 
-$string['privacy:metadata:lti_client'] = 'In order to integrate with a remote openEQUELLA LTI service, user data needs to be exchanged with that service. Contact your openEQUELLA administrator for more information';
+$string['privacy:metadata:lti_client'] = 'In order to integrate with a remote openEQUELLA LTI service, user data needs to be exchanged with that service. Contact your openEQUELLA administrator for more information.';
 $string['privacy:metadata:lti_client:userid'] = 'The userid is sent from Moodle to allow you to access your data on the remote system.';
 $string['privacy:metadata:lti_client:givenname'] = 'Your given name is sent to the openEQUELLA system for SSO login';
 $string['privacy:metadata:lti_client:familyname'] = 'Your family name is sent to the openEQUELLA system for SSO login';

--- a/lang/en/equella.php
+++ b/lang/en/equella.php
@@ -165,3 +165,14 @@ $string['push.attachment'] = 'Selected attachment';
 */
 
 $string['webserviceerror'] = '{$a}';
+
+////////////////////////////////////////////////////////
+// GDPR compliance
+
+$string['privacy:metadata:lti_client'] = 'In order to integrate with a remote openEQUELLA LTI service, user data needs to be exchanged with that service. Contact your openEQUELLA administrator for more information';
+$string['privacy:metadata:lti_client:userid'] = 'The userid is sent from Moodle to allow you to access your data on the remote system.';
+$string['privacy:metadata:lti_client:givenname'] = 'Your given name is sent to the openEQUELLA system for SSO login';
+$string['privacy:metadata:lti_client:familyname'] = 'Your family name is sent to the openEQUELLA system for SSO login';
+$string['privacy:metadata:lti_client:fullname'] = 'Your full name is sent to the openEQUELLA system for SSO login';
+$string['privacy:metadata:lti_client:email'] = 'Your email address is sent to the openEQUELLA system for SSO login';
+$string['privacy:metadata:lti_client:roles'] = 'Your moodle roles are sent to the openEQUELLA system, which allows to allow you to access your data on the remote system.';

--- a/lang/en/equella.php
+++ b/lang/en/equella.php
@@ -175,4 +175,4 @@ $string['privacy:metadata:lti_client:givenname'] = 'Your given name is sent to t
 $string['privacy:metadata:lti_client:familyname'] = 'Your family name is sent to the openEQUELLA system for SSO login';
 $string['privacy:metadata:lti_client:fullname'] = 'Your full name is sent to the openEQUELLA system for SSO login';
 $string['privacy:metadata:lti_client:email'] = 'Your email address is sent to the openEQUELLA system for SSO login';
-$string['privacy:metadata:lti_client:roles'] = 'Your moodle roles are sent to the openEQUELLA system, which allows to allow you to access your data on the remote system.';
+$string['privacy:metadata:lti_client:roles'] = 'Your Moodle roles are sent to the openEQUELLA system, which allows you to access your data on the remote system.';

--- a/version.php
+++ b/version.php
@@ -15,7 +15,7 @@
 // along with Moodle. If not, see <http://www.gnu.org/licenses/>.
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020031100;
+$plugin->version   = 2020031301;
 $plugin->requires  = 2014041101;    // Requires this Moodle version
 $plugin->component = 'mod_equella'; // Full name of the plugin (used for diagnostics)
 $plugin->release = '1.0';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/moodle-mod_openEQUELLA/issues
-->

##### Checklist

<!-- For completed items, change [ ] to [x]. For items which don't apply, please suffix with N/A -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes
- [x] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
https://github.com/openequella/moodle-mod_openEQUELLA/issues/49

This commit implements the Moodle privacy api. In particular defining what personally identifiable details are sent through to oEQ during an lti launch.

This can be viewed via 
Site administration->Users->Privacy and policies->Plugin privacy registry->Activity Modules
![data privacy registry](https://user-images.githubusercontent.com/4625498/76593587-e3ad6b80-654a-11ea-9d1c-b8a50047d141.PNG)

The majority of the Privacy api methods have been left implemented, as oEQ does not store any personally identifiable moodle user details.


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
