### PR TITLE
adjust iframe width based on window size

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-03-16 Nick Charles
+
+	Make selection session window 80% of window width
+
 2020-03-11 Nick Charles
 
 	Replace starburst icons with open sourced versions

--- a/module.js
+++ b/module.js
@@ -77,8 +77,8 @@ M.mod_equella.display_equella = function(Y, equellaContainer, minwidth, minheigh
                 newwidth = initialwidth;
             }
 	} else {
-		newheight = get_htmlelement_size(parentContainer, 'height');
-		newwidth = get_htmlelement_size(parentContainer, 'width');
+	    newheight = get_htmlelement_size(parentContainer, 'height');
+	    newwidth = get_htmlelement_size(parentContainer, 'width');
 	}
         newheight = newheight - 50;
 	obj.setStyle('height', newheight + 'px');

--- a/module.js
+++ b/module.js
@@ -12,7 +12,8 @@ M.mod_equella.display_equella = function(Y, equellaContainer, width, minheight,
 	title, redirecturl) {
     var bodyNode = Y.one('body');
     var iframeid = 'resourceobject';
-    var initialheight = Y.one('body').get('winHeight') * 0.9;
+	var initialheight = Y.one('body').get('winHeight') * 0.9;
+	var initialwidth = Y.one('body').get('winWidth') * 0.8;
     bodyNode.addClass('equella-page');
 
     var generate_html = function(append) {
@@ -52,6 +53,7 @@ M.mod_equella.display_equella = function(Y, equellaContainer, width, minheight,
 	obj.setStyle('width', '0px');
 	obj.setStyle('height', '0px');
 	var newwidth = get_htmlelement_size(parentContainer, 'width') - 25;
+	
 
 	if (newwidth > 500) {
 	    obj.setStyle('width', newwidth + 'px');
@@ -90,11 +92,11 @@ M.mod_equella.display_equella = function(Y, equellaContainer, width, minheight,
 	generate_html(true);
 	var panel = new Y.Panel({
 	    srcNode : '#' + equellaContainer,
-	    width : width,
+	    width : initialwidth,
 	    height : initialheight,
 	    zIndex : 4031,
 	    xy : [ x, y ],
-	    centered : false,
+	    centered : true,
 	    modal : true,
 	    visible : true,
 	    render : true,

--- a/module.js
+++ b/module.js
@@ -8,12 +8,12 @@ M.mod_equella.submitform = function(Y, formid) {
     frm.submit();
 };
 
-M.mod_equella.display_equella = function(Y, equellaContainer, width, minheight,
+M.mod_equella.display_equella = function(Y, equellaContainer, minwidth, minheight,
 	title, redirecturl) {
     var bodyNode = Y.one('body');
     var iframeid = 'resourceobject';
-	var initialheight = Y.one('body').get('winHeight') * 0.9;
-	var initialwidth = Y.one('body').get('winWidth') * 0.8;
+    var initialheight = Y.one('body').get('winHeight') * 0.9;
+    var initialwidth = Y.one('body').get('winWidth') * 0.8;
     bodyNode.addClass('equella-page');
 
     var generate_html = function(append) {
@@ -64,14 +64,21 @@ M.mod_equella.display_equella = function(Y, equellaContainer, width, minheight,
 	var headerheight = get_htmlelement_size('page-header', 'height');
 	var footerheight = get_htmlelement_size('page-footer', 'height');
 	var newheight;
+	var newwidth;
 	if (initialize) {
             if (initialheight < minheight) {
                 newheight = minheight;
             } else {
                 newheight = initialheight;
+            }	
+            if (initialwidth < minwidth) {
+                newwidth = minwidth;
+            } else {
+                newwidth = initialwidth;
             }
 	} else {
-	    newheight = get_htmlelement_size(parentContainer, 'height');
+		newheight = get_htmlelement_size(parentContainer, 'height');
+		newwidth = get_htmlelement_size(parentContainer, 'width');
 	}
         newheight = newheight - 50;
 	obj.setStyle('height', newheight + 'px');
@@ -86,7 +93,7 @@ M.mod_equella.display_equella = function(Y, equellaContainer, width, minheight,
 	    bodywidth = body.getComputedStyle('width');
 	}
 	bodywidth = parseInt(bodywidth);
-	var x = (bodywidth - width) / 2;
+	var x = (bodywidth - minwidth) / 2;
 	var y = 20;
 
 	generate_html(true);

--- a/version.php
+++ b/version.php
@@ -15,7 +15,7 @@
 // along with Moodle. If not, see <http://www.gnu.org/licenses/>.
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020031100;
+$plugin->version   = 2020031600;
 $plugin->requires  = 2014041101;    // Requires this Moodle version
 $plugin->component = 'mod_equella'; // Full name of the plugin (used for diagnostics)
 $plugin->release = '1.0';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/moodle-mod_openEQUELLA/issues
-->

##### Checklist

<!-- For completed items, change [ ] to [x]. For items which don't apply, please suffix with N/A -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
https://github.com/openequella/moodle-mod_openEQUELLA/issues/52

The iframe now uses an 80% width of the window. But currently this change doesn't really do much, due to oEQ selection session css using fixed widths 
(fixing that would require an additional change on the core oEQ codebase)

![moodle iframe sizing](https://user-images.githubusercontent.com/4625498/76719518-1a26f880-678e-11ea-9a36-ca898b32db94.PNG)


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
