### PR TITLE
bugfix: ensure web services return correct courses

### DIFF
--- a/externallib.php
+++ b/externallib.php
@@ -260,14 +260,8 @@ class equella_external extends external_api {
             }
 
             if ($modifiable) {
-                $contextrecord = new stdclass();
-                $contextrecord->id = $course->contextid;
-                $contextrecord->contextlevel = CONTEXT_COURSE;
-                $contextrecord->instanceid = $course->id;
-                $contextrecord->path = $course->path;
-                $contextrecord->depth = $course->depth;
-                $coursecontext = eq_context_course::get_from_record($contextrecord);
-                if (!has_capability(self::WRITE_PERMISSION, $coursecontext, $userobj)) {
+                $ctx = context_course::instance($course->id);
+                if (!has_capability(self::WRITE_PERMISSION, $ctx, $userobj)) {
                     continue;
                 }
             }

--- a/locallib.php
+++ b/locallib.php
@@ -749,14 +749,3 @@ XML;
         }
     }
 }
-
-class eq_context_course extends context_course {
-    public static function get_from_record($record) {
-        if ($context = context::cache_get(CONTEXT_COURSE, $record->id)) {
-            return $context;
-        }
-        $context = new context_course($record);
-        context::cache_add($context);
-        return $context;
-    }
-}


### PR DESCRIPTION
#80 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Make sure the web service returns correct courses when the parameter modifiable is set to true.
Many thanks to the community who provided the solution and @SammyIsConfused who did lots of testing.