### PR TITLE
feat: create a new page to do LTI 1.3 migration

### DIFF
--- a/lang/en/equella.php
+++ b/lang/en/equella.php
@@ -102,6 +102,11 @@ $string['config.lti.secret.help'] = 'Client secret is required if LTI is enabled
 $string['config.lti.liscallback.title'] = 'Outcome callback URL';
 
 ////////////////////////////////////////////////////////
+// LTI 1.3 migration
+$string['config.lti13.migration.title'] = 'LTI 1.3 Migration';
+$string['config.lti13.migration.description'] = 'Migrate openEquella resources to use LTI 1.3';
+
+////////////////////////////////////////////////////////
 // CONFIGURATION: Shared Secrets
 
 $string['config.sharedsecrets.heading'] = 'Shared Secret Settings';

--- a/lang/en/equella.php
+++ b/lang/en/equella.php
@@ -104,7 +104,7 @@ $string['config.lti.liscallback.title'] = 'Outcome callback URL';
 ////////////////////////////////////////////////////////
 // LTI 1.3 migration
 $string['config.lti13.migration.title'] = 'LTI 1.3 Migration';
-$string['config.lti13.migration.description'] = 'Migrate openEquella resources to use LTI 1.3';
+$string['config.lti13.migration.description'] = 'Migrate openEQUELLA resources to use LTI 1.3';
 
 ////////////////////////////////////////////////////////
 // CONFIGURATION: Shared Secrets

--- a/lti13migration.php
+++ b/lti13migration.php
@@ -13,15 +13,28 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle. If not, see <http://www.gnu.org/licenses/>.
+
  echo "
-  <h2>Update oEQ resource links to use LTI 1.3</h2>
-  <div>
-    <div>
-      Click <a href='?action=download'>here</a> to download the CSV of courses that will be affected by the migration.
-    </div>
-    <div>
-      Click <a href='?action=migrate'  onclick='return confirm(\"Please make sure you have done backed up the Moodle database.\")'>here</a> to start the migration.
-    </div>
-  </div>
+   <body>
+      <h1>Update oEQ resource links to use LTI 1.3</h1>
+
+      <p>
+        Before starting the migration, you can download a CSV which will list all courses which contain items that will be affected by the migration.
+        This CSV can be used for review, and no system modifications will occur.
+      </p>
+      <form method='GET'>
+        <input type='hidden' value='download' name='action'>
+        <input type='submit' value='Download CSV'>
+      </form>
+
+      <p>
+        This migration will enable existing openEQUELLA links to be opened using LTI 1.3 technology. openEQUELLA items shown in courses may display slightly differently
+        (e.g. use different thumbnails) after the migration. Please ensure that you have backed up your Moodle data before proceeding.
+      </p>
+      <form method='GET'>
+        <input type='hidden' value='migrate' name='action'>
+        <input type='submit' value='Start migration'  onclick='return confirm(\"Please ensure that you have backed up your Moodle data before proceeding.\")'>
+      </form>
+   </body>
 ";
 

--- a/lti13migration.php
+++ b/lti13migration.php
@@ -1,40 +1,49 @@
+<!--
+This file is part of the EQUELLA module - http://git.io/vUuof
+
+Moodle is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Moodle is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Moodle. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+<head><title>LTI 1.3 Migration</title>
+</head>
+<body>
+
 <?php
-// This file is part of the EQUELLA module - http://git.io/vUuof
-//
-// Moodle is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// Moodle is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Moodle. If not, see <http://www.gnu.org/licenses/>.
+echo "
+  <h1>Update oEQ resource links to use LTI 1.3</h1>
 
- echo "
-   <body>
-      <h1>Update oEQ resource links to use LTI 1.3</h1>
+  <p>
+    Before starting the migration, you can download a CSV which will list all courses which contain items that will be
+    affected by the migration. This CSV can be used for review, and no system modifications will occur.
+  </p>
+  <form method='GET'>
+    <input type='hidden' value='download' name='action'>
+    <input type='submit' value='Download CSV'>
+  </form>
 
-      <p>
-        Before starting the migration, you can download a CSV which will list all courses which contain items that will be affected by the migration.
-        This CSV can be used for review, and no system modifications will occur.
-      </p>
-      <form method='GET'>
-        <input type='hidden' value='download' name='action'>
-        <input type='submit' value='Download CSV'>
-      </form>
+  <p>
+    This migration will enable existing openEQUELLA links to be opened using LTI 1.3 technology. openEQUELLA items shown
+    in courses may display slightly differently (e.g. use different thumbnails) after the migration. Please ensure that 
+    you have backed up your Moodle data before proceeding.
+  </p>
+  <form method='GET'>
+    <input type='hidden' value='migrate' name='action'>
+    <input type='submit' value='Start migration'  onclick='return confirm(\"Please ensure that you have backed up your Moodle data before proceeding.\")'>
+  </form>"
+?>
 
-      <p>
-        This migration will enable existing openEQUELLA links to be opened using LTI 1.3 technology. openEQUELLA items shown in courses may display slightly differently
-        (e.g. use different thumbnails) after the migration. Please ensure that you have backed up your Moodle data before proceeding.
-      </p>
-      <form method='GET'>
-        <input type='hidden' value='migrate' name='action'>
-        <input type='submit' value='Start migration'  onclick='return confirm(\"Please ensure that you have backed up your Moodle data before proceeding.\")'>
-      </form>
-   </body>
-";
-
+</body>
+</html>

--- a/lti13migration.php
+++ b/lti13migration.php
@@ -1,0 +1,27 @@
+<?php
+// This file is part of the EQUELLA module - http://git.io/vUuof
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle. If not, see <http://www.gnu.org/licenses/>.
+ echo "
+  <h2>Update oEQ resource links to use LTI 1.3</h2>
+  <div>
+    <div>
+      Click <a href='?action=download'>here</a> to download the CSV of courses that will be affected by the migration.
+    </div>
+    <div>
+      Click <a href='?action=migrate'  onclick='return confirm(\"Please make sure you have done backed up the Moodle database.\")'>here</a> to start the migration.
+    </div>
+  </div>
+";
+

--- a/settings.php
+++ b/settings.php
@@ -106,6 +106,10 @@ if ($ADMIN->fulltree) {
 
     $settings->add($intercepttype);
 
+    // ///////////////////////////////////////////////////////////////////////////////
+    //
+    // LTI 1.3 migration
+    //
     $settings->add(new admin_setting_heading('equella_lti_migration', ecs('lti13.migration.title'), ''));
     $lti13MigrationUrl = new moodle_url('/mod/equella/lti13migration.php');
     $settings->add(new admin_setting_openlink('lti13migration', ecs('lti13.migration.title'), ecs('lti13.migration.description'), $lti13MigrationUrl->out()));

--- a/settings.php
+++ b/settings.php
@@ -105,4 +105,8 @@ if ($ADMIN->fulltree) {
     $intercepttype = new admin_setting_configselect('equella_intercept_files', get_string('interceptfiles', 'equella'), get_string('interceptfilesintro', 'equella'), 0, $choices);
 
     $settings->add($intercepttype);
+
+    $settings->add(new admin_setting_heading('equella_lti_migration', ecs('lti13.migration.title'), ''));
+    $lti13MigrationUrl = new moodle_url('/mod/equella/lti13migration.php');
+    $settings->add(new admin_setting_openlink('lti13migration', ecs('lti13.migration.title'), ecs('lti13.migration.description'), $lti13MigrationUrl->out()));
 }


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

In the settings page, there is new link which points to the LTI 1.3 migration page.

Please note the migration page has only some placeholder UI in this PR.

![image](https://github.com/openequella/moodle-mod_openEQUELLA/assets/47203811/a786fa43-20b4-4e2a-97fa-a97cf22ce4e6)


![image](https://github.com/openequella/moodle-mod_openEQUELLA/assets/47203811/f8a57495-0c8a-48c3-9f9f-9c9da88ac9d9)
