### PR TITLE
Feature/create adhoc task to run the migration

### DIFF
--- a/classes/task/lti13_migration_task.php
+++ b/classes/task/lti13_migration_task.php
@@ -1,0 +1,132 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_equella\task;
+
+use core\task\adhoc_task;
+use dml_exception;
+use stdClass;
+
+global $CFG;
+require_once($CFG->dirroot . '/mod/lti/lib.php');
+require_once($CFG->dirroot . '/mod/lti/locallib.php');
+
+class lti13_migration_task extends adhoc_task
+{
+    /**
+     * Create a new LTI external tool instance based on the provided course module info, details of the OEQ instance used in this
+     * course module and the configurations of an LTI external tool.
+     *
+     * @param $courseModule stdClass An instance of CourseModule to be updated to use LTI 1.3 as its module.
+     * @param $ltiToolDetails stdClass Details of the LTI external tool to be used to generate a new LTI instance.
+     *
+     * @throws dml_exception
+     */
+    private function createLtiInstance($courseModule, $ltiToolDetails): int
+    {
+        global $DB;
+
+        $oeqInstance = $DB->get_record('equella', array('id' => $courseModule->instance));
+        $ltiConfigurations = $ltiToolDetails->configurations;
+        $ltiToolID = $ltiToolDetails->id;
+
+        $lti = new stdClass();
+
+        $lti->typeid = $ltiToolID;
+
+        $lti->course = $courseModule->course;
+        $lti->showdescriptionlaunch = $courseModule->showdescription;
+        $lti->coursemodule = $courseModule->id;
+
+        $lti->icon = unserialize($oeqInstance->metadata)['thumbnail'];
+        $lti->intro = $oeqInstance->intro;
+        $lti->introformat = $oeqInstance->introformat;
+        $lti->name = $oeqInstance->name;
+        $lti->timecreated = $oeqInstance->timecreated;
+        $lti->timemodified = $oeqInstance->timemodified;
+        $lti->toolurl = $oeqInstance->url;
+
+        $lti->instructorchoicesendname = $ltiConfigurations['sendname'] ?? 1;
+        $lti->instructorchoicesendmailaddr = $ltiConfigurations['sendemailaddr'] ?? 1;
+        $lti->instructorchoiceacceptgrades = $ltiConfigurations['acceptgrades'] == LTI_SETTING_ALWAYS ? $ltiConfigurations['acceptgrades'] : 0;
+        $lti->instructorchoiceallowsetting = $ltiConfigurations['ltiservice_toolsettings'] ?? null;
+        $lti->instructorchoiceallowroster = $ltiConfigurations['allowroster ltiservice_memberships'] ?? null;
+        $lti->instructorcustomparameters = $ltiConfigurations['customparameters'] ?? "";
+        $lti->launchcontainer = $ltiConfigurations['launchcontainer'];
+
+        return lti_add_instance($lti, null); // The second parameter is not used at all in this function.;
+    }
+
+    /**
+     * Update an existing course module to use a new LTI instance. To achieve this, the value of `module` needs to be
+     * updated to the ID of LTI module, and the value of instance needs to be updated to the ID of a new LTI instance.
+     *
+     * @param $courseModule stdClass An instance of CourseModule to be updated to use LTI 1.3 as its module.
+     * @param $ltiToolDetails stdClass Details of the LTI external tool to be used to generate a new LTI instance.
+     * @param $ltiModuleID int ID of the LTI module.
+     *
+     * @throws dml_exception
+     */
+    private function updateCourseModule($courseModule, $ltiToolDetails, $ltiModuleID): void
+    {
+        global $DB;
+
+        $courseModule->module = $ltiModuleID;
+        $courseModule->instance = $this->createLtiInstance($courseModule, $ltiToolDetails);
+        $DB->update_record("course_modules", $courseModule);
+    }
+
+    /**
+     * Return the ID of Moodle module for the provided module name.
+     *
+     * @param $moduleName string Name of a Moodle module.
+     *
+     * @throws dml_exception
+     */
+    private  function getModuleId($moduleName) {
+        global $DB;
+        return $DB->get_field_sql("SELECT id FROM {modules} WHERE name = '$moduleName'");
+    }
+
+    public function execute()
+    {
+        global $DB;
+
+        try {
+            $oeqMoodleModuleID = $this->getModuleId('equella');
+            $ltiModuleID = $this->getModuleId('lti');
+
+            $ltiTool = new stdClass();
+            $ltiTypeName = $this->get_custom_data();
+            $ltiTypeID = $DB->get_field_sql("SELECT id FROM {lti_types} WHERE name = '" . $ltiTypeName . "'");
+            $ltiTool->id = $ltiTypeID;
+            $ltiTool->configurations = lti_get_type_config($ltiTypeID);
+
+            $courseModuleList = $DB->get_records_sql("SELECT * FROM {course_modules} cm WHERE cm.module = " . $oeqMoodleModuleID);
+
+            foreach ($courseModuleList as $cm) {
+                echo "Processing course ID: " . $cm->course . " openEQUELLA resource ID: " . $cm->instance . "\n";
+                $this->updateCourseModule($cm, $ltiTool, $ltiModuleID);
+            }
+
+            echo "LTI 1.3 migration has been successfully completed!";
+        } catch (dml_exception $e) {
+            echo "LTI 1.3 migration failed: $e";
+        }
+    }
+
+
+}

--- a/lti13migration/main.php
+++ b/lti13migration/main.php
@@ -22,6 +22,12 @@ along with Moodle. If not, see <http://www.gnu.org/licenses/>.
 <body>
 
 <?php
+require_once('../../../config.php');
+global $DB;
+
+$ltiToolNames = $DB->get_fieldset_sql("SELECT name FROM {lti_types} WHERE ltiversion='1.3.0'");
+$options = implode(array_map(function ($name) { return "<option value='$name'>$name</option>"; }, $ltiToolNames));
+
 echo "
   <h1>Update oEQ resource links to use LTI 1.3</h1>
 
@@ -38,8 +44,10 @@ echo "
     in courses may display slightly differently (e.g. use different thumbnails) after the migration. Please ensure that 
     you have backed up your Moodle data before proceeding.
   </p>
-  <form method='GET'>
-    <input type='hidden' value='migrate' name='action'>
+  <form method='GET' action='migrate.php'>
+
+    <label for=\"ltiTypeName\">Please select the LTI 1.3 tool you want to use in the migration</label>
+    <select name='ltiTypeName'> $options </select> 
     <input type='submit' value='Start migration'  onclick='return confirm(\"Please ensure that you have backed up your Moodle data before proceeding.\")'>
   </form>"
 ?>

--- a/lti13migration/migrate.php
+++ b/lti13migration/migrate.php
@@ -1,0 +1,47 @@
+<?php
+require_once('../../../config.php');
+
+function buildUrl($page) {
+    return (new moodle_url($page)) -> out(false);
+}
+
+$runningTasksPage = buildUrl('/admin/tool/task/runningtasks.php');
+$taskLogsPage = buildUrl('/admin/tasklogs.php');
+$purgeCachePage = buildUrl('/admin/purgecaches.php');
+
+$task = new \mod_equella\task\lti13_migration_task();
+$task -> set_custom_data($_GET['ltiTypeName']);
+\core\task\manager::queue_adhoc_task($task);
+?>
+
+<!DOCTYPE html>
+<html lang="en">
+<head><title>LTI 1.3 Migration</title>
+</head>
+<body>
+  <h1>Update oEQ resource links to use LTI 1.3</h1>
+
+  <p>
+    A Moodle adhoc task has been submitted to do the migration.
+  </p>
+  <p>
+    However, when the task will start depends on how often the Moodle cron script is executed.
+  </p>
+  <p>
+    <?php
+      echo "
+        You can check whether the task is in progress in the 
+        <a href='$runningTasksPage' target='_blank'>Running tasks page</a>, 
+        and you can find out the task result in the <a href='$taskLogsPage' target='_blank'>Task logs page</a>.";
+    ?>
+  </p>
+  <p>
+    <?php 
+      echo "
+        Once the task is completed, if none of the oEQ resources have been updated, you need to clear your caches.
+        You can do that in the <a href='$purgeCachePage' target='_blank'>Purge caches page</a>.";
+    ?>
+  </p>
+</body>
+</html>
+


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes
- [x] documentation is changed or added

##### Description of change

The LTI 1.3 migration could take a lot of time to complete. As a result, a Moodle adhoc task should be the best choice for this task. So in this PR,

* a new adhoc task is added to do the job
* a new page is added to submit the task
* the main page is updated to allow users to select which LTI external tool to be used in the migration

The attached video will show you  the performance for 1000 courses and 100000 resources.


https://github.com/openequella/moodle-mod_openEQUELLA/assets/47203811/1ed511fa-8fdd-4716-92b5-f2acd90f46ba


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
