### PR TITLE
fix: Make sure that require 'config.php' is first

### DIFF
--- a/lti13migration/main.php
+++ b/lti13migration/main.php
@@ -1,3 +1,7 @@
+<?php
+require_once('../../../config.php');
+?>
+
 <!--
 This file is part of the EQUELLA module - http://git.io/vUuof
 
@@ -22,7 +26,6 @@ along with Moodle. If not, see <http://www.gnu.org/licenses/>.
 <body>
 
 <?php
-require_once('../../../config.php');
 global $DB;
 
 $ltiToolNames = $DB->get_fieldset_sql("SELECT name FROM {lti_types} WHERE ltiversion='1.3.0'");


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/moodle-mod_openEQUELLA/issues
-->

##### Checklist

<!-- For completed items, change [ ] to [x]. For items which don't apply, please suffix with N/A -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] screenshots are included showing significant UI changes
  - not applicable
- [ ] documentation is changed or added
  - not applicable

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Although on some configurations existing code works, on others it will result in attempting to create a session after a response has already started. General moodle guidance is that `require_once('config.php')` should be first in any files which are the result of requests dealt with the `handler.php`.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
