### PR TITLE
fix the 'add' module page javascript failing on Moodle 4.3+

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -113,6 +113,8 @@ class mod_equella_mod_form extends moodleform_mod {
             // When conditional access is enabled, moodle expects id_availabilityconditionsjson field
             // in standard module form, as we don't use standard form.
             echo html_writer::start_tag('form', array('style'=>'display:none'));
+            echo html_writer::tag('div', '', array('id' => 'fitem_id_availabilityconditionsjson'));
+            echo html_writer::tag('div', '', array('id' => 'availabilityconditions-loading'));
             echo html_writer::empty_tag('input', array('id'=>'id_availabilityconditionsjson', 'type'=>'hidden'));
             echo html_writer::end_tag('form');
         } else {


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed — the CLA URL is a 404 now, and I had signed it under a different github username anyway
- [x] commit message follows [commit guidelines][]
- [ ] screenshots are included showing significant UI changes — N/A
- [ ] documentation is changed or added — N/A

##### Description of change

From Moodle 4.3, [YUI module moodle-core_availability-form](https://github.com/moodle/moodle/blob/MOODLE_403_STABLE/availability/yui/src/form/js/form.js#L148-L150) now expects to find elements with ids `fitem_id_availabilityconditionsjson` and `availabilityconditions-loading`.

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
