### PR TITLE
fix 'find uses' feature failing from 4.3 onwards

### DIFF
--- a/externallib.php
+++ b/externallib.php
@@ -857,8 +857,11 @@ class equella_external extends external_api {
     static private function get_instructors($courseid) {
         global $DB;
 
-        // XXX get_all_user_name_fields() exists 2.6 onward
-        if (function_exists('get_all_user_name_fields')) {
+        if (class_exists('core_user\\fields')) {
+            // Class core_user\fields exists from 3.11 onward.
+            $ufields = \core_user\fields::for_name()->get_sql('u', false, '', '', false)->selects;
+        } else if (function_exists('get_all_user_name_fields')) {
+            // Function get_all_user_name_fields() exists 2.6 onward.
             $ufields = get_all_user_name_fields(true, 'u');
         } else {
             $ufields = 'u.firstname,u.lastname';


### PR DESCRIPTION

##### Checklist

<!-- For completed items, change [ ] to [x]. For items which don't apply, please suffix with N/A -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

get_all_user_name_fields() was deprecated in 3.11, became an error-emitting stub in [4.3](https://github.com/moodle/moodle/blob/MOODLE_403_STABLE/lib/deprecatedlib.php#L2795), and was removed fully in 4.5.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/about/governance/licensing
[commit guidelines]: https://chris.beams.io/posts/git-commit/
