### PR TITLE
Fix deprecated openssl_free_key function

### DIFF
--- a/oauthlocallib.php
+++ b/oauthlocallib.php
@@ -258,8 +258,7 @@ class OAuthSignatureMethod_RSA_SHA1 extends OAuthSignatureMethod {
 
         // Release the key resource
         if(PHP_VERSION_ID < 80000)
-            openssl_free_key($privatekeyid); // this function is deprecated from PHP v8.0 onwards, no manual cleanup required - handles by PHP garbage collector
-
+            openssl_free_key($privatekeyid);  // todo: remove this if statement and the use of `openssl_free_key` as this function is deprecated from PHP v8.0 onwards
         return base64_encode($signature);
     }
 
@@ -279,7 +278,7 @@ class OAuthSignatureMethod_RSA_SHA1 extends OAuthSignatureMethod {
 
         // Release the key resource
         if(PHP_VERSION_ID < 80000)
-            openssl_free_key($publickeyid); // this function is deprecated from PHP v8.0 onwards, no manual cleanup required - handles by PHP garbage collector
+            openssl_free_key($publickeyid);  // todo: remove this if statement and the use of `openssl_free_key` as this function is deprecated from PHP v8.0 onwards
 
         return $ok == 1;
     }

--- a/oauthlocallib.php
+++ b/oauthlocallib.php
@@ -257,7 +257,8 @@ class OAuthSignatureMethod_RSA_SHA1 extends OAuthSignatureMethod {
         $ok = openssl_sign($base_string, $signature, $privatekeyid);
 
         // Release the key resource
-        openssl_free_key($privatekeyid);
+        if(PHP_VERSION_ID < 80000)
+            openssl_free_key($privatekeyid); // this function is deprecated from PHP v8.0 onwards, no manual cleanup required - handles by PHP garbage collector
 
         return base64_encode($signature);
     }
@@ -277,7 +278,8 @@ class OAuthSignatureMethod_RSA_SHA1 extends OAuthSignatureMethod {
         $ok = openssl_verify($base_string, $decoded_sig, $publickeyid);
 
         // Release the key resource
-        openssl_free_key($publickeyid);
+        if(PHP_VERSION_ID < 80000)
+            openssl_free_key($publickeyid); // this function is deprecated from PHP v8.0 onwards, no manual cleanup required - handles by PHP garbage collector
 
         return $ok == 1;
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/moodle-mod_openEQUELLA/issues
-->

##### Checklist

<!-- For completed items, change [ ] to [x]. For items which don't apply, please suffix with N/A -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] screenshots are included showing significant UI changes
- [x] documentation is changed or added

##### Description of change

Fixed the deprecated function, openssl_free_key, calls in oauthlocallib.php for the issue [!98](https://github.com/openequella/moodle-mod_openEQUELLA/issues/98)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/about/governance/licensing
[commit guidelines]: https://chris.beams.io/posts/git-commit/
