### PR TITLE
fix:Migrate Equella Plugin Settings from Global Config to Config Plugins Table

### DIFF
--- a/common/lib.php
+++ b/common/lib.php
@@ -33,8 +33,7 @@ function get_block_configdata($blockname) {
  * @return string
  */
 function equella_full_url($urlpart) {
-    global $CFG;
-    return str_ireplace('signon.do', $urlpart, $CFG->equella_url);
+    return str_ireplace('signon.do', $urlpart, get_config('equella', 'equella_url'));
 }
 
 /**
@@ -83,17 +82,17 @@ function equella_getssotoken($course = null) {
 
         if ($hassystemrole || $hascategoryrole || $hascourserole) {
             // see if the user has a role that is linked to an equella role
-            $shareid = $CFG->{"equella_{$role->shortname}_shareid"};
+            $shareid = $CFG->get_config('equella', "equella_{$role->shortname}_shareid");
             if (!empty($shareid)) {
-                return equella_getssotoken_raw($USER->username, $shareid, $CFG->{"equella_{$role->shortname}_sharedsecret"});
+                return equella_getssotoken_raw($USER->username, $shareid, get_config('equella', "equella_{$role->shortname}_sharedsecret"));
             }
         }
     }
 
     // no roles found, use the default shareid and secret
-    $shareid = $CFG->equella_shareid;
+    $shareid = get_config('equella', 'equella_shareid');
     if (!empty($shareid)) {
-        return equella_getssotoken_raw($USER->username, $shareid, $CFG->equella_sharedsecret);
+        return equella_getssotoken_raw($USER->username, $shareid, get_config('equella', 'equella_sharedsecret'));
     }
 }
 
@@ -138,8 +137,7 @@ function equella_appendtoken($url, $token = null) {
     return $url;
 }
 function equella_getssotoken_api() {
-    global $CFG;
-    return equella_getssotoken_raw($CFG->equella_admin_username, $CFG->equella_shareid, $CFG->equella_sharedsecret);
+    return equella_getssotoken_raw(get_config('equella', 'equella_admin_username'), get_config('equella', 'equella_shareid'), get_config('equella', 'equella_sharedsecret'));
 }
 
 /**

--- a/common/lib.php
+++ b/common/lib.php
@@ -82,7 +82,7 @@ function equella_getssotoken($course = null) {
 
         if ($hassystemrole || $hascategoryrole || $hascourserole) {
             // see if the user has a role that is linked to an equella role
-            $shareid = $CFG->get_config('equella', "equella_{$role->shortname}_shareid");
+            $shareid = get_config('equella', "equella_{$role->shortname}_shareid");
             if (!empty($shareid)) {
                 return equella_getssotoken_raw($USER->username, $shareid, get_config('equella', "equella_{$role->shortname}_sharedsecret"));
             }

--- a/common/lib.php
+++ b/common/lib.php
@@ -33,7 +33,7 @@ function get_block_configdata($blockname) {
  * @return string
  */
 function equella_full_url($urlpart) {
-    return str_ireplace('signon.do', $urlpart, get_config('equella', 'equella_url'));
+    return str_ireplace('signon.do', $urlpart, equella_get_config('equella_url'));
 }
 
 /**
@@ -82,17 +82,17 @@ function equella_getssotoken($course = null) {
 
         if ($hassystemrole || $hascategoryrole || $hascourserole) {
             // see if the user has a role that is linked to an equella role
-            $shareid = get_config('equella', "equella_{$role->shortname}_shareid");
+            $shareid = equella_get_config("equella_{$role->shortname}_shareid");
             if (!empty($shareid)) {
-                return equella_getssotoken_raw($USER->username, $shareid, get_config('equella', "equella_{$role->shortname}_sharedsecret"));
+                return equella_getssotoken_raw($USER->username, $shareid, equella_get_config("equella_{$role->shortname}_sharedsecret"));
             }
         }
     }
 
     // no roles found, use the default shareid and secret
-    $shareid = get_config('equella', 'equella_shareid');
+    $shareid = equella_get_config('equella_shareid');
     if (!empty($shareid)) {
-        return equella_getssotoken_raw($USER->username, $shareid, get_config('equella', 'equella_sharedsecret'));
+        return equella_getssotoken_raw($USER->username, $shareid, equella_get_config('equella_sharedsecret'));
     }
 }
 
@@ -137,7 +137,7 @@ function equella_appendtoken($url, $token = null) {
     return $url;
 }
 function equella_getssotoken_api() {
-    return equella_getssotoken_raw(get_config('equella', 'equella_admin_username'), get_config('equella', 'equella_shareid'), get_config('equella', 'equella_sharedsecret'));
+    return equella_getssotoken_raw(equella_get_config('equella_admin_username'), equella_get_config('equella_shareid'), equella_get_config('equella_sharedsecret'));
 }
 
 /**

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -248,5 +248,14 @@ function xmldb_equella_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2015041401, 'equella');
     }
 
+    if($oldversion < 2025021101){
+        foreach ($CFG as $x => $y){
+            if(strpos($x, 'equella')!==false){
+                set_config($x, $y, 'equella');
+                unset_config($x);
+            }
+        }
+    }
+
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -255,6 +255,8 @@ function xmldb_equella_upgrade($oldversion) {
                 unset_config($x);
             }
         }
+
+        upgrade_mod_savepoint(true, 2025021101, 'equella');
     }
 
     return true;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -249,10 +249,20 @@ function xmldb_equella_upgrade($oldversion) {
     }
 
     if($oldversion < 2025021101){
+        // These keys are not part of admin settings but are stored in $CFG
+        $excluded_keys = [
+            'equella_soap_disable_ssl_check',
+            'equella_oauth_access_token',
+            'equella_lti_lis_callback',
+            'equella_oauth_client_id'
+        ];
         foreach ($CFG as $x => $y){
             if(strpos($x, 'equella')!==false){
-                set_config($x, $y, 'equella');
-                unset_config($x);
+                if (!in_array($x, $excluded_keys, true)) {
+                    set_config($x, $y, 'equella');
+                    unset_config($x);
+                }
+
             }
         }
 

--- a/equella_rest_api.php
+++ b/equella_rest_api.php
@@ -714,7 +714,7 @@ class equella_rest_api {
     const OAUTH_URI = 'oauth/authorise';
     const TOKEN_URI = 'oauth/access_token';
     public static function get_end_point() {
-        $eq_url = get_config('equella', 'equella_url');
+        $eq_url = equella_get_config('equella_url');
         if (empty($eq_url)) {
             throw new moodle_exception('equella url not set');
         }

--- a/equella_rest_api.php
+++ b/equella_rest_api.php
@@ -714,11 +714,11 @@ class equella_rest_api {
     const OAUTH_URI = 'oauth/authorise';
     const TOKEN_URI = 'oauth/access_token';
     public static function get_end_point() {
-        global $CFG;
-        if (empty($CFG->equella_url)) {
+        $eq_url = get_config('equella', 'equella_url');
+        if (empty($eq_url)) {
             throw new moodle_exception('equella url not set');
         }
-        $url = substr($CFG->equella_url, 0, strlen($CFG->equella_url) - strlen('signon.do'));
+        $url = substr($eq_url, 0, strlen($eq_url) - strlen('signon.do'));
         $url = rtrim($url, '/') . '/';
         return $url;
     }

--- a/lib.php
+++ b/lib.php
@@ -82,13 +82,13 @@ function equella_supports($feature) {
 }
 function equella_get_window_options() {
     $width = EQUELLA_DEFAULT_WINDOW_WIDTH;
-    if (!empty(get_config('equella', 'equella_default_window_width'))) {
-        $width = get_config('equella', 'equella_default_window_width');
+    if (!empty(equella_get_config('equella_default_window_width'))) {
+        $width = equella_get_config('equella_default_window_width');
     }
 
     $height = EQUELLA_DEFAULT_WINDOW_HEIGHT;
-    if (!empty(get_config('equella', 'equella_default_window_height'))) {
-        $height = get_config('equella', 'equella_default_window_height');
+    if (!empty(equella_get_config('equella_default_window_height'))) {
+        $height = equella_get_config('equella_default_window_height');
     }
 
     return array('width' => $width,'height' => $height,'resizable' => 1,'scrollbars' => 1,'directories' => 0,'location' => 0,'menubar' => 0,'toolbar' => 0,'status' => 0);
@@ -111,7 +111,7 @@ function equella_add_instance($equella, $mform = null) {
     global $DB, $CFG;
     $equella->timecreated = time();
     $equella->timemodified = time();
-    if (!empty(get_config('equella', 'equella_open_in_new_window'))) {
+    if (!empty(equella_get_config('equella_open_in_new_window'))) {
         $equella->windowpopup = 1;
     }
     $equella = equella_postprocess($equella);
@@ -178,7 +178,7 @@ function equella_delete_instance($id) {
     }
 
     if ($equella->activation) {
-        $url = str_replace("signon.do", "access/activationwebservice.do", get_config('equella', 'equella_url'));
+        $url = str_replace("signon.do", "access/activationwebservice.do", equella_get_config('equella_url'));
         $url = equella_appendtoken($url) . "&activationUuid=" . rawurlencode($equella->activation);
         $curl = curl_init($url);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
@@ -293,7 +293,7 @@ function equella_find_repository() {
     require_once ($CFG->dirroot . '/repository/lib.php');
     $instances = repository::get_instances(array('type' => 'equella'));
     foreach($instances as $e) {
-        if ($e->get_option('equella_url') == get_config('equella', 'equella_url')) {
+        if ($e->get_option('equella_url') == equella_get_config('equella_url')) {
             return $e;
         }
     }
@@ -333,10 +333,10 @@ function equella_module_event_handler($event) {
     global $CFG;
     require_once ($CFG->dirroot . '/mod/equella/locallib.php');
 
-    if (empty(get_config('equella', 'equella_intercept_files'))) {
+    if (empty(equella_get_config('equella_intercept_files'))) {
         return;
     }
-    if ((int)get_config('equella', 'equella_intercept_files') != EQUELLA_CONFIG_INTERCEPT_FULL) {
+    if ((int)equella_get_config('equella_intercept_files') != EQUELLA_CONFIG_INTERCEPT_FULL) {
         return;
     }
     $course = equella_get_course($event->courseid);
@@ -386,7 +386,7 @@ function equella_handle_mod_updated($event) {
  *
  * @return array containing details of the files / types the mod can handle
  */
-if ((int)get_config('equella', 'equella_intercept_files') == EQUELLA_CONFIG_INTERCEPT_ASK) {
+if ((int)equella_get_config( 'equella_intercept_files') == EQUELLA_CONFIG_INTERCEPT_ASK) {
     function equella_dndupload_register() {
         return array('files' => array(array('extension' => '*','message' => get_string('dnduploadresource', 'mod_equella'))));
     }
@@ -397,7 +397,7 @@ if ((int)get_config('equella', 'equella_intercept_files') == EQUELLA_CONFIG_INTE
  *
  * @return array containing details of the files / types the mod can handle
  */
-if ((int)get_config('equella', 'equella_intercept_files') == EQUELLA_CONFIG_INTERCEPT_META) {
+if ((int)equella_get_config('equella_intercept_files') == EQUELLA_CONFIG_INTERCEPT_META) {
     function equella_dndupload_register() {
         global $PAGE, $CFG, $COURSE;
         $config = [
@@ -414,7 +414,7 @@ if ((int)get_config('equella', 'equella_intercept_files') == EQUELLA_CONFIG_INTE
 }
 
 //https://github.com/equella/moodle-mod_equella/issues/60
-if ((int)get_config('equella', 'equella_intercept_files') == EQUELLA_CONFIG_INTERCEPT_NONE) {
+if ((int)equella_get_config( 'equella_intercept_files') == EQUELLA_CONFIG_INTERCEPT_NONE) {
     function equella_dndupload_register() {
         return null;
     }
@@ -634,3 +634,12 @@ function equella_grade_item_delete($eq) {
     return grade_update(EQUELLA_SOURCE, $eq->courseid, EQUELLA_ITEM_TYPE, EQUELLA_ITEM_MODULE, $eq->id, 0, NULL, array('deleted'=>1));
 }
 
+/**
+ * Retrieve an Equella configuration setting.
+ *
+ * @param string $configname The name of the configuration setting.
+ * @return mixed The value of the configuration setting.
+ */
+function equella_get_config($configname){
+    return get_config('equella', $configname);
+}

--- a/lib.php
+++ b/lib.php
@@ -81,15 +81,14 @@ function equella_supports($feature) {
     }
 }
 function equella_get_window_options() {
-    global $CFG;
     $width = EQUELLA_DEFAULT_WINDOW_WIDTH;
-    if (!empty($CFG->equella_default_window_width)) {
-        $width = $CFG->equella_default_window_width;
+    if (!empty(get_config('equella', 'equella_default_window_width'))) {
+        $width = get_config('equella', 'equella_default_window_width');
     }
 
     $height = EQUELLA_DEFAULT_WINDOW_HEIGHT;
-    if (!empty($CFG->equella_default_window_height)) {
-        $height = $CFG->equella_default_window_height;
+    if (!empty(get_config('equella', 'equella_default_window_height'))) {
+        $height = get_config('equella', 'equella_default_window_height');
     }
 
     return array('width' => $width,'height' => $height,'resizable' => 1,'scrollbars' => 1,'directories' => 0,'location' => 0,'menubar' => 0,'toolbar' => 0,'status' => 0);
@@ -112,7 +111,7 @@ function equella_add_instance($equella, $mform = null) {
     global $DB, $CFG;
     $equella->timecreated = time();
     $equella->timemodified = time();
-    if (!empty($CFG->equella_open_in_new_window)) {
+    if (!empty(get_config('equella', 'equella_open_in_new_window'))) {
         $equella->windowpopup = 1;
     }
     $equella = equella_postprocess($equella);
@@ -179,7 +178,7 @@ function equella_delete_instance($id) {
     }
 
     if ($equella->activation) {
-        $url = str_replace("signon.do", "access/activationwebservice.do", $CFG->equella_url);
+        $url = str_replace("signon.do", "access/activationwebservice.do", get_config('equella', 'equella_url'));
         $url = equella_appendtoken($url) . "&activationUuid=" . rawurlencode($equella->activation);
         $curl = curl_init($url);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
@@ -294,7 +293,7 @@ function equella_find_repository() {
     require_once ($CFG->dirroot . '/repository/lib.php');
     $instances = repository::get_instances(array('type' => 'equella'));
     foreach($instances as $e) {
-        if ($e->get_option('equella_url') == $CFG->equella_url) {
+        if ($e->get_option('equella_url') == get_config('equella', 'equella_url')) {
             return $e;
         }
     }
@@ -334,10 +333,10 @@ function equella_module_event_handler($event) {
     global $CFG;
     require_once ($CFG->dirroot . '/mod/equella/locallib.php');
 
-    if (empty($CFG->equella_intercept_files)) {
+    if (empty(get_config('equella', 'equella_intercept_files'))) {
         return;
     }
-    if ((int)$CFG->equella_intercept_files != EQUELLA_CONFIG_INTERCEPT_FULL) {
+    if ((int)get_config('equella', 'equella_intercept_files') != EQUELLA_CONFIG_INTERCEPT_FULL) {
         return;
     }
     $course = equella_get_course($event->courseid);
@@ -387,7 +386,7 @@ function equella_handle_mod_updated($event) {
  *
  * @return array containing details of the files / types the mod can handle
  */
-if (isset($CFG->equella_intercept_files) && (int)$CFG->equella_intercept_files == EQUELLA_CONFIG_INTERCEPT_ASK) {
+if ((int)get_config('equella', 'equella_intercept_files') == EQUELLA_CONFIG_INTERCEPT_ASK) {
     function equella_dndupload_register() {
         return array('files' => array(array('extension' => '*','message' => get_string('dnduploadresource', 'mod_equella'))));
     }
@@ -398,7 +397,7 @@ if (isset($CFG->equella_intercept_files) && (int)$CFG->equella_intercept_files =
  *
  * @return array containing details of the files / types the mod can handle
  */
-if (isset($CFG->equella_intercept_files) && (int)$CFG->equella_intercept_files == EQUELLA_CONFIG_INTERCEPT_META) {
+if ((int)get_config('equella', 'equella_intercept_files') == EQUELLA_CONFIG_INTERCEPT_META) {
     function equella_dndupload_register() {
         global $PAGE, $CFG, $COURSE;
         $config = [
@@ -415,7 +414,7 @@ if (isset($CFG->equella_intercept_files) && (int)$CFG->equella_intercept_files =
 }
 
 //https://github.com/equella/moodle-mod_equella/issues/60
-if (isset($CFG->equella_intercept_files) && (int)$CFG->equella_intercept_files == EQUELLA_CONFIG_INTERCEPT_NONE) {
+if ((int)get_config('equella', 'equella_intercept_files') == EQUELLA_CONFIG_INTERCEPT_NONE) {
     function equella_dndupload_register() {
         return null;
     }

--- a/locallib.php
+++ b/locallib.php
@@ -93,7 +93,7 @@ function equella_get_course_contents($courseid, $sectionid) {
  */
 function equella_embed_general($equella) {
     global $PAGE;
-    if (get_config('equella', 'equella_enable_lti')) {
+    if (equella_get_config('equella_enable_lti')) {
         $launchurl = new moodle_url('/mod/equella/ltilaunch.php', array('cmid' => $equella->cmid,'action' => 'view'));
         $url = $launchurl->out();
     } else {
@@ -116,7 +116,7 @@ function equella_embed_general($equella) {
         $ie5 = check_browser_version($vendor, $version);
     }
 
-    if ($ie5 || get_config('equella', 'equella_enable_lti')) {
+    if ($ie5 || equella_get_config('equella_enable_lti')) {
         $iframe = true;
     }
 
@@ -160,12 +160,12 @@ function equella_select_dialog($args) {
 
     $equrl = equella_build_integration_url($args);
 
-    if (get_config('equella', 'equella_enable_lti')) {
+    if (equella_get_config('equella_enable_lti')) {
         $args->action = 'select';
         $launchurl = new moodle_url('/mod/equella/ltilaunch.php', (array)$args);
         $objecturl = $launchurl->out(false);
     } else {
-        if (get_config('equella', 'equella_action') == EQUELLA_ACTION_STRUCTURED) {
+        if (equella_get_config('equella_action') == EQUELLA_ACTION_STRUCTURED) {
             $redirecturl = new moodle_url('/mod/equella/redirectselection.php', array('equellaurl' => $equrl->out(false),'courseid' => $args->course,'sectionid' => $args->section));
             $objecturl = $redirecturl->out(false);
         } else {
@@ -248,7 +248,7 @@ function equella_build_integration_url($args, $appendtoken = true) {
         'template' => 'standard',
         'courseId' => $args->course,
         'courseCode' => $coursecode,
-        'action' => get_config('equella', 'equella_action'),
+        'action' => equella_get_config('equella_action'),
         'selectMultiple' => 'true',
         'cancelDisabled' => 'true',
         'returnurl' => $callbackurl->out(false),
@@ -263,15 +263,15 @@ function equella_build_integration_url($args, $appendtoken = true) {
         $course = equella_get_course($args->course);
         $equrlparams['token'] = equella_getssotoken($course);
     }
-    if (!empty(get_config('equella', 'equella_options'))) {
-        $equrlparams['options'] = get_config('equella', 'equella_options');
+    if (!empty(equella_get_config('equella_options'))) {
+        $equrlparams['options'] = equella_get_config('equella_options');
     }
-    $restriction = get_config('equella', 'equella_select_restriction');
+    $restriction = equella_get_config('equella_select_restriction');
     if ($restriction && $restriction != EQUELLA_CONFIG_SELECT_RESTRICT_NONE) {
         $equrlparams[$restriction] = 'true';
     }
 
-    return new moodle_url(get_config('equella', 'equella_url'), $equrlparams);
+    return new moodle_url(equella_get_config('equella_url'), $equrlparams);
 }
 
 //Based on w3c standard, line breaks, as in multi-line text field values, are represented as CR LF pairs, i.e. `%0D%0A'
@@ -530,8 +530,8 @@ class equella_lti_oauth extends oauth_helper {
     }
 
     public static function sign_params($url, $params, $method) {
-        $key = get_config('equella', 'equella_lti_oauth_key');
-        $secret = get_config('equella', 'equella_lti_oauth_secret');
+        $key = equella_get_config('equella_lti_oauth_key');
+        $secret = equella_get_config('equella_lti_oauth_secret');
         if (empty($key) || empty($secret)) {
             return $params;
         }
@@ -541,7 +541,7 @@ class equella_lti_oauth extends oauth_helper {
     public static function verify_message($message) {
         require_once dirname(__FILE__) . '/' . 'oauthlocallib.php';
         try {
-            moodle\mod\equella\handle_oauth_body_post(get_config('equella', 'equella_lti_oauth_key'), get_config('equella', 'equella_lti_oauth_secret'), $message);
+            moodle\mod\equella\handle_oauth_body_post(equella_get_config('equella_lti_oauth_key'), equella_get_config('equella_lti_oauth_secret'), $message);
         } catch(Exception $e) {
             return false;
         }

--- a/locallib.php
+++ b/locallib.php
@@ -92,8 +92,8 @@ function equella_get_course_contents($courseid, $sectionid) {
  * @return string html
  */
 function equella_embed_general($equella) {
-    global $CFG, $PAGE;
-    if ($CFG->equella_enable_lti) {
+    global $PAGE;
+    if (get_config('equella', 'equella_enable_lti')) {
         $launchurl = new moodle_url('/mod/equella/ltilaunch.php', array('cmid' => $equella->cmid,'action' => 'view'));
         $url = $launchurl->out();
     } else {
@@ -116,7 +116,7 @@ function equella_embed_general($equella) {
         $ie5 = check_browser_version($vendor, $version);
     }
 
-    if ($ie5 || $CFG->equella_enable_lti) {
+    if ($ie5 || get_config('equella', 'equella_enable_lti')) {
         $iframe = true;
     }
 
@@ -156,16 +156,16 @@ EOT;
  * @return string html
  */
 function equella_select_dialog($args) {
-    global $CFG, $PAGE;
+    global $PAGE;
 
     $equrl = equella_build_integration_url($args);
 
-    if ($CFG->equella_enable_lti) {
+    if (get_config('equella', 'equella_enable_lti')) {
         $args->action = 'select';
         $launchurl = new moodle_url('/mod/equella/ltilaunch.php', (array)$args);
         $objecturl = $launchurl->out(false);
     } else {
-        if ($CFG->equella_action == EQUELLA_ACTION_STRUCTURED) {
+        if (get_config('equella', 'equella_action') == EQUELLA_ACTION_STRUCTURED) {
             $redirecturl = new moodle_url('/mod/equella/redirectselection.php', array('equellaurl' => $equrl->out(false),'courseid' => $args->course,'sectionid' => $args->section));
             $objecturl = $redirecturl->out(false);
         } else {
@@ -216,8 +216,7 @@ function equella_parse_query($str) {
 }
 
 function equella_build_integration_url($args, $appendtoken = true) {
-    global $USER, $CFG;
-
+    global $USER;
     $callbackurlparams = array('course' => $args->course,'section' => $args->section);
 
     if (!empty($args->cmid)) {
@@ -249,7 +248,7 @@ function equella_build_integration_url($args, $appendtoken = true) {
         'template' => 'standard',
         'courseId' => $args->course,
         'courseCode' => $coursecode,
-        'action' => $CFG->equella_action,
+        'action' => get_config('equella', 'equella_action'),
         'selectMultiple' => 'true',
         'cancelDisabled' => 'true',
         'returnurl' => $callbackurl->out(false),
@@ -264,14 +263,15 @@ function equella_build_integration_url($args, $appendtoken = true) {
         $course = equella_get_course($args->course);
         $equrlparams['token'] = equella_getssotoken($course);
     }
-    if (!empty($CFG->equella_options)) {
-        $equrlparams['options'] = $CFG->equella_options;
+    if (!empty(get_config('equella', 'equella_options'))) {
+        $equrlparams['options'] = get_config('equella', 'equella_options');
     }
-    if ($CFG->equella_select_restriction && $CFG->equella_select_restriction != EQUELLA_CONFIG_SELECT_RESTRICT_NONE) {
-        $equrlparams[$CFG->equella_select_restriction] = 'true';
+    $restriction = get_config('equella', 'equella_select_restriction');
+    if ($restriction && $restriction != EQUELLA_CONFIG_SELECT_RESTRICT_NONE) {
+        $equrlparams[$restriction] = 'true';
     }
 
-    return new moodle_url($CFG->equella_url, $equrlparams);
+    return new moodle_url(get_config('equella', 'equella_url'), $equrlparams);
 }
 
 //Based on w3c standard, line breaks, as in multi-line text field values, are represented as CR LF pairs, i.e. `%0D%0A'
@@ -530,9 +530,8 @@ class equella_lti_oauth extends oauth_helper {
     }
 
     public static function sign_params($url, $params, $method) {
-        global $CFG;
-        $key = $CFG->equella_lti_oauth_key;
-        $secret = $CFG->equella_lti_oauth_secret;
+        $key = get_config('equella', 'equella_lti_oauth_key');
+        $secret = get_config('equella', 'equella_lti_oauth_secret');
         if (empty($key) || empty($secret)) {
             return $params;
         }
@@ -540,10 +539,9 @@ class equella_lti_oauth extends oauth_helper {
     }
 
     public static function verify_message($message) {
-        global $CFG;
         require_once dirname(__FILE__) . '/' . 'oauthlocallib.php';
         try {
-            moodle\mod\equella\handle_oauth_body_post($CFG->equella_lti_oauth_key, $CFG->equella_lti_oauth_secret, $message);
+            moodle\mod\equella\handle_oauth_body_post(get_config('equella', 'equella_lti_oauth_key'), get_config('equella', 'equella_lti_oauth_secret'), $message);
         } catch(Exception $e) {
             return false;
         }

--- a/ltilaunch.php
+++ b/ltilaunch.php
@@ -73,7 +73,7 @@ if ($action == 'view') {
 
     $url = equella_build_integration_url($args, false);
     $extraparams = $url->params();
-    if (get_config('equella', 'equella_action') == EQUELLA_ACTION_STRUCTURED) {
+    if (equella_get_config('equella_action') == EQUELLA_ACTION_STRUCTURED) {
         $contents = equella_get_course_contents($course->id, $args->section);
         $json = json_encode($contents);
         $extraparams['structure'] = $json;
@@ -84,7 +84,7 @@ if ($action == 'view') {
     $equella = new stdClass();
     $equella->id = 0;
     $equella->course = $args->course;
-    $equella->url = get_config('equella', 'equella_url');
+    $equella->url = equella_get_config('equella_url');
     $params = equella_lti_params($equella, $course, $extraparams);
 
     echo '<html><body>';

--- a/ltilaunch.php
+++ b/ltilaunch.php
@@ -73,7 +73,7 @@ if ($action == 'view') {
 
     $url = equella_build_integration_url($args, false);
     $extraparams = $url->params();
-    if ($CFG->equella_action == EQUELLA_ACTION_STRUCTURED) {
+    if (get_config('equella', 'equella_action') == EQUELLA_ACTION_STRUCTURED) {
         $contents = equella_get_course_contents($course->id, $args->section);
         $json = json_encode($contents);
         $extraparams['structure'] = $json;
@@ -84,7 +84,7 @@ if ($action == 'view') {
     $equella = new stdClass();
     $equella->id = 0;
     $equella->course = $args->course;
-    $equella->url = $CFG->equella_url;
+    $equella->url = get_config('equella', 'equella_url');
     $params = equella_lti_params($equella, $course, $extraparams);
 
     echo '<html><body>';

--- a/popup.php
+++ b/popup.php
@@ -19,7 +19,7 @@ require_login();
 
 $cmid = required_param('cmid', PARAM_INT);
 
-if ($CFG->equella_enable_lti) {
+if (get_config('equella', 'equella_enable_lti')) {
     $url = new moodle_url('/mod/equella/ltilaunch.php', array('cmid' => $cmid));
 } else {
     $url = new moodle_url('/mod/equella/view.php', array('id' => $cmid,'inpopup' => true));

--- a/popup.php
+++ b/popup.php
@@ -19,7 +19,7 @@ require_login();
 
 $cmid = required_param('cmid', PARAM_INT);
 
-if (get_config('equella', 'equella_enable_lti')) {
+if (equella_get_config('equella_enable_lti')) {
     $url = new moodle_url('/mod/equella/ltilaunch.php', array('cmid' => $cmid));
 } else {
     $url = new moodle_url('/mod/equella/view.php', array('id' => $cmid,'inpopup' => true));

--- a/settings.php
+++ b/settings.php
@@ -35,31 +35,31 @@ if ($ADMIN->fulltree) {
     $changelogurl = new moodle_url('/mod/equella/changelog.php');
     $settings->add(new admin_setting_openlink('changelog', ecs('changelog.title'), ecs('changelog.desc'), $changelogurl->out()));
 
-    $settings->add(new admin_setting_configtext('equella_url', ecs('url.title'), ecs('url.desc'), ''));
-    $settings->add(new admin_setting_configtext('equella_action', ecs('action.title'), ecs('action.desc'), ''));
+    $settings->add(new admin_setting_configtext('equella/equella_url', ecs('url.title'), ecs('url.desc'), ''));
+    $settings->add(new admin_setting_configtext('equella/equella_action', ecs('action.title'), ecs('action.desc'), ''));
 
     $restrictionOptions = array(EQUELLA_CONFIG_SELECT_RESTRICT_NONE => trim(ecs('restriction.none')),EQUELLA_CONFIG_SELECT_RESTRICT_ITEMS_ONLY => trim(ecs('restriction.itemsonly')),EQUELLA_CONFIG_SELECT_RESTRICT_ATTACHMENTS_ONLY => trim(ecs('restriction.attachmentsonly')),
         EQUELLA_CONFIG_SELECT_RESTRICT_PACKAGES_ONLY => trim(ecs('restriction.packagesonly')));
 
-    $settings->add(new admin_setting_configselect('equella_select_restriction', ecs('restriction.title'), ecs('restriction.desc'), EQUELLA_CONFIG_SELECT_RESTRICT_NONE, $restrictionOptions));
+    $settings->add(new admin_setting_configselect('equella/equella_select_restriction', ecs('restriction.title'), ecs('restriction.desc'), EQUELLA_CONFIG_SELECT_RESTRICT_NONE, $restrictionOptions));
 
-    $settings->add(new admin_setting_configtextarea('equella_options', ecs('options.title'), ecs('options.desc'), ''));
+    $settings->add(new admin_setting_configtextarea('equella/equella_options', ecs('options.title'), ecs('options.desc'), ''));
 
-    $settings->add(new admin_setting_configtext('equella_admin_username', ecs('adminuser.title'), ecs('adminuser.desc'), ''));
-    $settings->add(new admin_setting_configcheckbox('equella_open_in_new_window', ecs('open.newwindow'), '', 1));
+    $settings->add(new admin_setting_configtext('equella/equella_admin_username', ecs('adminuser.title'), ecs('adminuser.desc'), ''));
+    $settings->add(new admin_setting_configcheckbox('equella/equella_open_in_new_window', ecs('open.newwindow'), '', 1));
 
-    $settings->add(new admin_setting_configtext('equella_default_window_width', ecs('window.width'), '', EQUELLA_DEFAULT_WINDOW_WIDTH));
+    $settings->add(new admin_setting_configtext('equella/equella_default_window_width', ecs('window.width'), '', EQUELLA_DEFAULT_WINDOW_WIDTH));
 
-    $settings->add(new admin_setting_configtext('equella_default_window_height', ecs('window.height'), '', EQUELLA_DEFAULT_WINDOW_HEIGHT));
+    $settings->add(new admin_setting_configtext('equella/equella_default_window_height', ecs('window.height'), '', EQUELLA_DEFAULT_WINDOW_HEIGHT));
 
     // ///////////////////////////////////////////////////////////////////////////////
     //
     // LTI
     //
     $settings->add(new admin_setting_heading('equella_lti_settings', ecs('lti.heading'), ecs('lti.help')));
-    $settings->add(new admin_setting_configcheckbox('equella_enable_lti', ecs('enablelti'), ecs('enablelti.desc'), 0));
-    $settings->add(new admin_setting_configtext('equella_lti_oauth_key', ecs('lti.key.title'), ecs('lti.key.help'), ''));
-    $settings->add(new admin_setting_configtext('equella_lti_oauth_secret', ecs('lti.secret.title'), ecs('lti.secret.help'), ''));
+    $settings->add(new admin_setting_configcheckbox('equella/equella_enable_lti', ecs('enablelti'), ecs('enablelti.desc'), 0));
+    $settings->add(new admin_setting_configtext('equella/equella_lti_oauth_key', ecs('lti.key.title'), ecs('lti.key.help'), ''));
+    $settings->add(new admin_setting_configtext('equella/equella_lti_oauth_secret', ecs('lti.secret.title'), ecs('lti.secret.help'), ''));
 
     // ///////////////////////////////////////////////////////////////////////////////
     //
@@ -71,8 +71,8 @@ if ($ADMIN->fulltree) {
     $description = '';
 
     $settings->add(new equella_setting_left_heading('equella_default_group', ecs('group', ecs('group.default')), ''));
-    $settings->add(new admin_setting_configtext('equella_shareid', ecs('sharedid.title'), $description, $defaultvalue));
-    $settings->add(new admin_setting_configtext('equella_sharedsecret', ecs('sharedsecret.title'), $description, $defaultvalue));
+    $settings->add(new admin_setting_configtext('equella/equella_shareid', ecs('sharedid.title'), $description, $defaultvalue));
+    $settings->add(new admin_setting_configtext('equella/equella_sharedsecret', ecs('sharedsecret.title'), $description, $defaultvalue));
 
     $rolearchetypes = get_role_archetypes();
     foreach(get_all_editing_roles() as $role) {
@@ -88,8 +88,8 @@ if ($ADMIN->fulltree) {
         $sectionname = 'equella_' . $shortname . '_role_group';
         $settings->add(new equella_setting_left_heading($sectionname, $heading, ''));
 
-        $settings->add(new admin_setting_configtext("equella_{$shortname}_shareid", ecs('sharedid.title'), $description, $defaultvalue, PARAM_TEXT));
-        $settings->add(new admin_setting_configtext("equella_{$shortname}_sharedsecret", ecs('sharedsecret.title'), $description, $defaultvalue, PARAM_TEXT));
+        $settings->add(new admin_setting_configtext("equella/equella_{$shortname}_shareid", ecs('sharedid.title'), $description, $defaultvalue, PARAM_TEXT));
+        $settings->add(new admin_setting_configtext("equella/equella_{$shortname}_sharedsecret", ecs('sharedsecret.title'), $description, $defaultvalue, PARAM_TEXT));
     }
     // ///////////////////////////////////////////////////////////////////////////////
     //
@@ -102,7 +102,7 @@ if ($ADMIN->fulltree) {
         EQUELLA_CONFIG_INTERCEPT_META => get_string('interceptmetadata', 'equella')
         //EQUELLA_CONFIG_INTERCEPT_FULL => get_string('interceptauto', 'equella')
     );
-    $intercepttype = new admin_setting_configselect('equella_intercept_files', get_string('interceptfiles', 'equella'), get_string('interceptfilesintro', 'equella'), 0, $choices);
+    $intercepttype = new admin_setting_configselect('equella/equella_intercept_files', get_string('interceptfiles', 'equella'), get_string('interceptfilesintro', 'equella'), 0, $choices);
 
     $settings->add($intercepttype);
 

--- a/version.php
+++ b/version.php
@@ -15,7 +15,7 @@
 // along with Moodle. If not, see <http://www.gnu.org/licenses/>.
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023070300;
+$plugin->version   = 2025021101;
 $plugin->requires  = 2014041101;    // Requires this Moodle version
 $plugin->component = 'mod_equella'; // Full name of the plugin (used for diagnostics)
 $plugin->release = '1.3.1';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/moodle-mod_openEQUELLA/issues
-->

##### Checklist

<!-- For completed items, change [ ] to [x]. For items which don't apply, please suffix with N/A -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
This PR addresses the [#40](https://github.com/openequella/moodle-mod_openEQUELLA/issues/40) issue.
This PR updates the openEquella plugin settings to use the config_plugins table instead of the global config table. Previously, settings were stored as global variables (e.g., $CFG->equella_url), which is not the recommended Moodle practice. I should be stored in config_plugins table.

Key Changes:

- Updated settings.php to use equella/equella_* instead of equella_* (moved all settings to the config_plugins table).
- Modified all occurrences of $CFG->equella_* to get_config('equella', 'equella_*').
- Updated the version in version.php and added an upgrade migration script in db/upgrade.php to move existing settings from config to config_plugins. Also removed the settings from global config table (or $CFG).
<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/about/governance/licensing
[commit guidelines]: https://chris.beams.io/posts/git-commit/
