### PR TITLE
Fix: mod equella frankenstyle prefix for the classes and functions

### DIFF
--- a/adminsettings.class.php
+++ b/adminsettings.class.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle. If not, see <http://www.gnu.org/licenses/>.
 require_once ($CFG->libdir . '/adminlib.php');
-class admin_setting_statictext extends admin_setting {
+class equella_admin_setting_statictext extends admin_setting {
     public $text;
     public function __construct($name, $visiblename, $description, $text) {
         parent::__construct($name, $visiblename, $description, null);
@@ -31,7 +31,7 @@ class admin_setting_statictext extends admin_setting {
         return format_admin_setting($this, $this->visiblename, $this->text, $this->description, true);
     }
 }
-class admin_setting_radiobuttons extends admin_setting {
+class equella_admin_setting_radiobuttons extends admin_setting {
     public $text;
     private $options;
     public function __construct($name, $visiblename, $description, $defaultsetting, $options) {
@@ -78,7 +78,7 @@ class admin_setting_radiobuttons extends admin_setting {
         return format_admin_setting($this, $this->visiblename, $selecthtml, $this->description, true);
     }
 }
-class admin_setting_openlink extends admin_setting {
+class equella_admin_setting_openlink extends admin_setting {
     public $url;
     public function __construct($name, $visiblename, $description, $url) {
         parent::__construct($name, $visiblename, $description, null);

--- a/classes/utils/utility.php
+++ b/classes/utils/utility.php
@@ -2,6 +2,8 @@
 
 namespace mod_equella\utils;
 
+defined('MOODLE_INTERNAL') || die();
+
 class utility
 {
     /**

--- a/classes/utils/utility.php
+++ b/classes/utils/utility.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace mod_equella\utils;
+
+class utility
+{
+    /**
+     * Converts all newline characters to CR LF pairs.
+     *
+     * Based on the W3C standard, multi-line text field values use CR LF.
+     * This function converts all "\n" to "\r\n".
+     *
+     * @param string $content The text to convert.
+     * @return string The converted text.
+     */
+    public static function convert_newline_characters($content) {
+        return preg_replace("/\r?\n/", "\r\n", $content);
+    }
+}

--- a/common/lib.php
+++ b/common/lib.php
@@ -65,7 +65,7 @@ function equella_getssotoken($course = null) {
     $context_c = context_course::instance($course->id);
 
     // roles are ordered by shortname
-    $editingroles = get_all_editing_roles();
+    $editingroles = equella_get_all_editing_roles();
     foreach($editingroles as $role) {
         $hassystemrole = false;
         if (!empty($context_sys)) {
@@ -145,7 +145,7 @@ function equella_getssotoken_api() {
  *
  * @return array
  */
-function get_all_editing_roles() {
+function equella_get_all_editing_roles() {
     global $DB;
     $sql = "SELECT r.id,r.shortname,r.name,r.sortorder,r.archetype,r.description
               FROM {role} r

--- a/common/soap.php
+++ b/common/soap.php
@@ -64,47 +64,47 @@ class EQUELLA {
         $this->client->logout();
     }
     public function getItem($uuid, $version) {
-        return new XMLWrapper($this->client->getItem(array('in0' => $uuid,'in1' => $version,'in2' => '*'))->out);
+        return new mod_equella_XMLWrapper($this->client->getItem(array('in0' => $uuid,'in1' => $version,'in2' => '*'))->out);
     }
 
     /**
      *
-     * @return XMLWrapper
+     * @return mod_equella_XMLWrapper
      */
     public function searchItems($query, $collectionUuids, $where, $onlylive, $sorttype, $reversesort, $offset, $maxresults) {
-        return new XMLWrapper($this->client->searchItems(array('in0' => $query,'in1' => $collectionUuids,'in2' => $where,'in3' => $onlylive,'in4' => $sorttype,'in5' => $reversesort,'in6' => $offset,'in7' => $maxresults))->out);
+        return new mod_equella_XMLWrapper($this->client->searchItems(array('in0' => $query,'in1' => $collectionUuids,'in2' => $where,'in3' => $onlylive,'in4' => $sorttype,'in5' => $reversesort,'in6' => $offset,'in7' => $maxresults))->out);
     }
 
     /**
      *
-     * @return XMLWrapper
+     * @return mod_equella_XMLWrapper
      */
     public function searchableCollections() {
-        return new XMLWrapper($this->client->getSearchableCollections()->out);
+        return new mod_equella_XMLWrapper($this->client->getSearchableCollections()->out);
     }
 
     /**
      *
-     * @return XMLWrapper
+     * @return mod_equella_XMLWrapper
      */
     public function contributableCollections() {
-        return new XMLWrapper($this->client->getContributableCollections()->out);
+        return new mod_equella_XMLWrapper($this->client->getContributableCollections()->out);
     }
     public function getTaskFilterCounts($ignoreZero = false) {
-        return new XMLWrapper($this->client->getTaskFilterCounts(array('in0' => $ignoreZero))->out);
+        return new mod_equella_XMLWrapper($this->client->getTaskFilterCounts(array('in0' => $ignoreZero))->out);
     }
 
     /**
      *
-     * @return XMLWrapper
+     * @return mod_equella_XMLWrapper
      */
     public function newItem($collectionUuid) {
-        return new XMLWrapper($this->client->newItem(array('in0' => $collectionUuid))->out);
+        return new mod_equella_XMLWrapper($this->client->newItem(array('in0' => $collectionUuid))->out);
     }
 
     /**
      *
-     * @param XMLWrapper
+     * @param mod_equella_XMLWrapper
      * @param int (boolean)
      */
     public function saveItem($item, $submit) {
@@ -119,10 +119,10 @@ class EQUELLA {
         $this->client->uploadFile(array('in0' => $stagingUuid,'in1' => $serverFilename,'in2' => $base64Data,'in3' => '1'));
     }
     public function getCollection($collectionUuid) {
-        return new XMLWrapper($this->client->getCollection(array('in0' => $collectionUuid))->out);
+        return new mod_equella_XMLWrapper($this->client->getCollection(array('in0' => $collectionUuid))->out);
     }
     public function getSchema($schemaUuid) {
-        return new XMLWrapper($this->client->getSchema(array('in0' => $schemaUuid))->out);
+        return new mod_equella_XMLWrapper($this->client->getSchema(array('in0' => $schemaUuid))->out);
     }
 }
 
@@ -130,7 +130,7 @@ class EQUELLA {
  * A wrapper around the DOMDocument and DOMXPath classes.
  * It is provided for convenience.
  */
-class XMLWrapper {
+class mod_equella_XMLWrapper {
     private $domDoc;
     private $xpathDoc;
     public function __construct($xmlString) {

--- a/locallib.php
+++ b/locallib.php
@@ -387,7 +387,7 @@ function equella_is_instructor($user, $cm, $courseid) {
     $context_c = context_course::instance($courseid);
 
     // roles are ordered by shortname
-    $editingroles = get_all_editing_roles();
+    $editingroles = equella_get_all_editing_roles();
     $isinstructor = false;
     foreach($editingroles as $role) {
         $hassystemrole = user_has_role_assignment($user->id, $role->id, $context_sys->id);

--- a/locallib.php
+++ b/locallib.php
@@ -20,6 +20,7 @@
 defined('MOODLE_INTERNAL') || die();
 require_once ($CFG->libdir . '/oauthlib.php');
 require_once ($CFG->dirroot . '/mod/equella/lib.php');
+use mod_equella\utils\utility;
 
 function equella_get_course_contents($courseid, $sectionid) {
     global $CFG;
@@ -274,14 +275,6 @@ function equella_build_integration_url($args, $appendtoken = true) {
     return new moodle_url(equella_get_config('equella_url'), $equrlparams);
 }
 
-//Based on w3c standard, line breaks, as in multi-line text field values, are represented as CR LF pairs, i.e. `%0D%0A'
-//which represents "\r\n".
-//In order to align newline characters between serverside and client side, and make sure the signature is matched,
-//we should convert all "\n" to "\r\n".
-function convert_newline_characters($content) {
-    return preg_replace("/\r?\n/", "\r\n", $content);
-}
-
 function equella_lti_params($equella, $course, $extra = array()) {
     global $USER, $CFG;
 
@@ -297,7 +290,7 @@ function equella_lti_params($equella, $course, $extra = array()) {
 
     $role = equella_lti_roles($USER, $equella->cmid, $equella->course);
 
-    $requestparams = array('resource_link_id' => $CFG->siteidentifier . ':mod_equella:' . $equella->cmid,'resource_link_title' => convert_newline_characters($equella->name),'resource_link_description' => convert_newline_characters($equella->intro),'user_id' => $USER->id,'roles' => $role,'context_id' => $course->id,'context_label' => $course->shortname,
+    $requestparams = array('resource_link_id' => $CFG->siteidentifier . ':mod_equella:' . $equella->cmid,'resource_link_title' => utility::convert_newline_characters($equella->name),'resource_link_description' => utility::convert_newline_characters($equella->intro),'user_id' => $USER->id,'roles' => $role,'context_id' => $course->id,'context_label' => $course->shortname,
         'context_title' => $course->fullname,'launch_presentation_locale' => current_language());
     if (!empty($equella->popup)) {
         $requestparams['launch_presentation_document_target'] = 'window';

--- a/settings.php
+++ b/settings.php
@@ -33,7 +33,7 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_heading('equella_general_settings', ecs('general.heading'), ''));
 
     $changelogurl = new moodle_url('/mod/equella/changelog.php');
-    $settings->add(new admin_setting_openlink('changelog', ecs('changelog.title'), ecs('changelog.desc'), $changelogurl->out()));
+    $settings->add(new equella_admin_setting_openlink('changelog', ecs('changelog.title'), ecs('changelog.desc'), $changelogurl->out()));
 
     $settings->add(new admin_setting_configtext('equella/equella_url', ecs('url.title'), ecs('url.desc'), ''));
     $settings->add(new admin_setting_configtext('equella/equella_action', ecs('action.title'), ecs('action.desc'), ''));
@@ -112,5 +112,5 @@ if ($ADMIN->fulltree) {
     //
     $settings->add(new admin_setting_heading('equella_lti_migration', ecs('lti13.migration.title'), ''));
     $lti13MigrationUrl = new moodle_url('/mod/equella/lti13migration/main.php');
-    $settings->add(new admin_setting_openlink('lti13migration', ecs('lti13.migration.title'), ecs('lti13.migration.description'), $lti13MigrationUrl->out()));
+    $settings->add(new equella_admin_setting_openlink('lti13migration', ecs('lti13.migration.title'), ecs('lti13.migration.description'), $lti13MigrationUrl->out()));
 }

--- a/settings.php
+++ b/settings.php
@@ -75,7 +75,7 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configtext('equella/equella_sharedsecret', ecs('sharedsecret.title'), $description, $defaultvalue));
 
     $rolearchetypes = get_role_archetypes();
-    foreach(get_all_editing_roles() as $role) {
+    foreach(equella_get_all_editing_roles() as $role) {
         $shortname = clean_param($role->shortname, PARAM_ALPHANUM);
         if (in_array($shortname, $rolearchetypes)) {
             $heading = ecs('group.' . $shortname);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/moodle-mod_openEQUELLA/issues
-->

##### Checklist

<!-- For completed items, change [ ] to [x]. For items which don't apply, please suffix with N/A -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR address the issue [#39](https://github.com/openequella/moodle-mod_openEQUELLA/issues/39)

I have refactored and renamed the classes and functions which were not upto the Moodle standard of having frankenstyle prefix.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/about/governance/licensing
[commit guidelines]: https://chris.beams.io/posts/git-commit/
