### PR TITLE
Fix: mod equella frankenstyle prefix for the classes and functions

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -112,9 +112,14 @@ class mod_equella_mod_form extends moodleform_mod {
             // This is a hack to make moodle believes certain html element exists.
             // When conditional access is enabled, moodle expects id_availabilityconditionsjson field
             // in standard module form, as we don't use standard form.
-            echo html_writer::start_tag('form', array('style'=>'display:none'));
-            echo html_writer::empty_tag('input', array('id'=>'id_availabilityconditionsjson', 'type'=>'hidden'));
-            echo html_writer::end_tag('form');
+            // When conditional access is enabled, moodle expects id_availabilityconditionsjson field, fitem_id_availabilityconditionsjson and availabilityconditions-loading in standard module form, as we don't use standard form.
+            if(!empty($CFG->enableavailability)){
+                echo html_writer::start_tag('form', array('style'=>'display:none'));
+                echo html_writer::tag('div', '', array('id' => 'fitem_id_availabilityconditionsjson'));
+                echo html_writer::tag('div', '', array('id' => 'availabilityconditions-loading'));
+                echo html_writer::empty_tag('input', array('id'=>'id_availabilityconditionsjson', 'type'=>'hidden'));
+                echo html_writer::end_tag('form');
+            }
         } else {
             parent::display();
         }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/moodle-mod_openEQUELLA/issues
-->

##### Checklist

<!-- For completed items, change [ ] to [x]. For items which don't apply, please suffix with N/A -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Update moodle-core_availability-form to support Moodle 4.3 changes

Description:
This PR address the issue where the OEQ selection session stopped loading from moodle v4.3 onwards. 

This PR builds on the discussion and suggested changes from [original PR #97](https://github.com/openequella/moodle-mod_openEQUELLA/pull/97) . 

From Moodle 4.3, [YUI module moodle-core_availability-form](https://github.com/moodle/moodle/blob/MOODLE_403_STABLE/availability/yui/src/form/js/form.js#L148-L150) now expects to find elements with ids fitem_id_availabilityconditionsjson and availabilityconditions-loading.



<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/about/governance/licensing
[commit guidelines]: https://chris.beams.io/posts/git-commit/
