### PR TITLE
Fix the popup window exception

### DIFF
--- a/popup.php
+++ b/popup.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle. If not, see <http://www.gnu.org/licenses/>.
 require_once ('../../config.php');
-
+require_once($CFG->dirroot . '/mod/equella/lib.php');
 require_login();
 
 $cmid = required_param('cmid', PARAM_INT);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/moodle-mod_openEQUELLA/issues
-->

##### Checklist

<!-- For completed items, change [ ] to [x]. For items which don't apply, please suffix with N/A -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR fixes an exception thrown `Exception - Call to undefined function equella_get_config()` when trying to view any openEQUELLA resource in moodle.
<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/about/governance/licensing
[commit guidelines]: https://chris.beams.io/posts/git-commit/
