### PR TITLE
Feature/new sso settings enhancement

### DIFF
--- a/classes/user_field.php
+++ b/classes/user_field.php
@@ -115,4 +115,18 @@ class user_field {
 
         return $fieldname;
     }
+
+    /**
+     * Get shortname for the current equella_userfield.
+     *
+     * @return string
+     */
+    public static function get_equella_userfield_short_name(): string {
+        $userfield = equella_get_config('equella_userfield');
+        if (self::is_custom_profile_field($userfield)) {
+            $userfield = substr($userfield, strlen(self::PROFILE_FIELD_PREFIX), strlen($userfield));
+        }
+
+        return $userfield;
+    }
 }

--- a/classes/user_field.php
+++ b/classes/user_field.php
@@ -121,12 +121,9 @@ class user_field {
      *
      * @return string
      */
-    public static function get_equella_userfield_short_name(): string {
+    public static function get_equella_userfield_display_name(): string {
         $userfield = equella_get_config('equella_userfield');
-        if (self::is_custom_profile_field($userfield)) {
-            $userfield = substr($userfield, strlen(self::PROFILE_FIELD_PREFIX), strlen($userfield));
-        }
-
-        return $userfield;
+        $options = self::get_supported_fields();
+        return $options[$userfield] ?? '';
     }
 }

--- a/common/lib.php
+++ b/common/lib.php
@@ -66,7 +66,7 @@ function equella_getssotoken($course = null) {
     }
     $context_c = context_course::instance($course->id);
 
-    $equellauserfield = mod_equella_get_userfield_value();
+    $ssoUserFieldVal = mod_equella_get_sso_userfield_value();
 
     // roles are ordered by shortname
     $editingroles = equella_get_all_editing_roles();
@@ -88,7 +88,7 @@ function equella_getssotoken($course = null) {
             // see if the user has a role that is linked to an equella role
             $shareid = equella_get_config("equella_{$role->shortname}_shareid");
             if (!empty($shareid)) {
-                return equella_getssotoken_raw($equellauserfield, $shareid, equella_get_config("equella_{$role->shortname}_sharedsecret"));
+                return equella_getssotoken_raw($ssoUserFieldVal, $shareid, equella_get_config("equella_{$role->shortname}_sharedsecret"));
             }
         }
     }
@@ -96,7 +96,7 @@ function equella_getssotoken($course = null) {
     // no roles found, use the default shareid and secret
     $shareid = equella_get_config('equella_shareid');
     if (!empty($shareid)) {
-        return equella_getssotoken_raw($equellauserfield, $shareid, equella_get_config('equella_sharedsecret'));
+        return equella_getssotoken_raw($ssoUserFieldVal, $shareid, equella_get_config('equella_sharedsecret'));
     }
 }
 

--- a/lang/en/equella.php
+++ b/lang/en/equella.php
@@ -158,7 +158,7 @@ You have received this email because you have sufficient permission to fix this.
 ////////////////////////////////////////////////////////
 // Errors and stuff
 $string['restapinolocation'] = 'No location returned';
-$string['erroruserfieldempty'] = 'Your {$a->field} field is empty. You must provide a valid {$a->field} to add or view openEQUELLA resource. Please update your profile or contact your administrator to ensure your {$a->field} is properly configured for single sign-on.';
+$string['erroruserfieldempty'] = 'Your {$a->field} field is empty. You must provide a valid {$a->field} to add or view openEQUELLA resources. Please update your profile or contact your administrator to ensure your {$a->field} is properly configured for single sign-on.';
 
 ////////////////////////////////////////////////////////
 // EQUELLA LMS PUSH

--- a/lang/en/equella.php
+++ b/lang/en/equella.php
@@ -158,6 +158,7 @@ You have received this email because you have sufficient permission to fix this.
 ////////////////////////////////////////////////////////
 // Errors and stuff
 $string['restapinolocation'] = 'No location returned';
+$string['erroruserfieldempty'] = 'Your {$a->field} field is empty. You must provide a valid {$a->field} to add or view openEQUELLA resource. Please update your profile or contact your administrator to ensure your {$a->field} is properly configured for single sign-on.';
 
 ////////////////////////////////////////////////////////
 // EQUELLA LMS PUSH

--- a/lib.php
+++ b/lib.php
@@ -645,11 +645,13 @@ function equella_get_config($configname){
 }
 
 /**
- * Retrieve the userfield/username for a current user.
+ * Get the user field value to be used for SSO identification.
+ *
+ * Returns the custom profile field value (if applicable) or the standard user field.
  *
  * @return string
  */
-function mod_equella_get_userfield_value(): string {
+function mod_equella_get_sso_userfield_value(): string {
     global $USER;
 
     // Figuring out user field from the configuration.

--- a/lib.php
+++ b/lib.php
@@ -652,19 +652,12 @@ function equella_get_config($configname){
 function mod_equella_get_userfield_value(): string {
     global $USER;
 
-    // Fall back to username.
-    $fieldvalue = $USER->username;
-
     // Figuring out user field from the configuration.
     $userfield = equella_get_config('equella_userfield');
     if (\mod_equella\user_field::is_custom_profile_field($userfield)) {
         $shortname = mod_equella\user_field::get_field_short_name($userfield);
-        if (!empty($USER->profile[$shortname])) {
-            $fieldvalue = $USER->profile[$shortname];
-        }
-    } else if (!empty($USER->$userfield)) {
-        $fieldvalue = $USER->$userfield;
+        return $USER->profile[$shortname];
+    } else {
+        return $USER->$userfield;
     }
-
-    return $fieldvalue;
 }

--- a/lib.php
+++ b/lib.php
@@ -656,7 +656,7 @@ function mod_equella_get_userfield_value(): string {
     $userfield = equella_get_config('equella_userfield');
     if (\mod_equella\user_field::is_custom_profile_field($userfield)) {
         $shortname = mod_equella\user_field::get_field_short_name($userfield);
-        return $USER->profile[$shortname];
+        return $USER->profile[$shortname] ?? "";
     } else {
         return $USER->$userfield;
     }

--- a/locallib.php
+++ b/locallib.php
@@ -289,7 +289,7 @@ function equella_lti_params($equella, $course, $extra = array()) {
     }
 
     $role = equella_lti_roles($USER, $equella->cmid, $equella->course);
-    $equellauserfield = mod_equella_get_userfield_value();
+    $ssoUserFieldVal = mod_equella_get_sso_userfield_value();
 
     $requestparams = array('resource_link_id' => $CFG->siteidentifier . ':mod_equella:' . $equella->cmid,'resource_link_title' => utility::convert_newline_characters($equella->name),'resource_link_description' => utility::convert_newline_characters($equella->intro),'user_id' => $USER->id,'roles' => $role,'context_id' => $course->id,'context_label' => $course->shortname,
         'context_title' => $course->fullname,'launch_presentation_locale' => current_language());
@@ -304,7 +304,7 @@ function equella_lti_params($equella, $course, $extra = array()) {
     $requestparams['lis_person_name_family'] = $USER->lastname;
     $requestparams['lis_person_name_full'] = fullname($USER);
     $requestparams['lis_person_contact_email_primary'] = $USER->email;
-    $requestparams['lis_person_sourcedid'] = $equellauserfield;
+    $requestparams['lis_person_sourcedid'] = $ssoUserFieldVal;
     $requestparams["ext_lms"] = "moodle-2";
     $requestparams['tool_consumer_info_product_family_code'] = 'moodle';
     $requestparams['tool_consumer_info_version'] = strval($CFG->version);
@@ -338,7 +338,7 @@ function equella_lti_params($equella, $course, $extra = array()) {
 function equella_add_lmsinfo_parameters(&$params, $course, $contributiontype) {
     global $USER, $DB;
 
-    $equellauserfield = mod_equella_get_userfield_value();
+    $ssoUserFieldVal = mod_equella_get_sso_userfield_value();
 
     $params['lms'] = 'Moodle';
     $params['contributiontype'] = $contributiontype;
@@ -347,7 +347,7 @@ function equella_add_lmsinfo_parameters(&$params, $course, $contributiontype) {
     $params['course/fullname'] = $course->fullname;
     $params['course/shortname'] = $course->shortname;
     $params['course/code'] = $course->idnumber;
-    $params['user/username'] = $equellauserfield;
+    $params['user/username'] = $ssoUserFieldVal;
     $params['user/firstname'] = $USER->firstname;
     $params['user/lastname'] = $USER->lastname;
     //$params['moodle/section'] = get_section_name($course, $sectionid));

--- a/ltilaunch.php
+++ b/ltilaunch.php
@@ -103,10 +103,10 @@ function get_item_xml($course, $sectionid) {
     $integmoodlexml = $integxml->addChild('moodle');
 
     // User
-    $equellauserfield = mod_equella_get_userfield_value();
+    $ssoUserFieldVal = mod_equella_get_sso_userfield_value();
 
     $integuserxml = $integxml->addChild('user');
-    $integuserxml->addChild('username', $equellauserfield);
+    $integuserxml->addChild('username', $ssoUserFieldVal);
     $integuserxml->addChild('firstname', $USER->firstname);
     $integuserxml->addChild('lastname', $USER->lastname);
 

--- a/mod_form.php
+++ b/mod_form.php
@@ -95,7 +95,7 @@ class mod_equella_mod_form extends moodleform_mod {
         }
         if ($this->is_adding_equella_resource() && equella_get_config('equella_enable_lti') && empty(mod_equella_get_userfield_value())) {
             $errparams = new stdClass();
-            $errparams->field = \mod_equella\user_field::get_equella_userfield_short_name();
+            $errparams->field = \mod_equella\user_field::get_equella_userfield_display_name();
             redirect(new moodle_url('/course/view.php', ['id' => $defaults['course']]),
                 get_string('erroruserfieldempty', 'mod_equella', $errparams),
                 null,

--- a/mod_form.php
+++ b/mod_form.php
@@ -93,7 +93,7 @@ class mod_equella_mod_form extends moodleform_mod {
                 }
             }
         }
-        if ($this->is_adding_equella_resource() && equella_get_config('equella_enable_lti') && empty(mod_equella_get_userfield_value())) {
+        if ($this->is_adding_equella_resource() && equella_get_config('equella_enable_lti') && empty(mod_equella_get_sso_userfield_value())) {
             $errparams = new stdClass();
             $errparams->field = \mod_equella\user_field::get_equella_userfield_display_name();
             redirect(new moodle_url('/course/view.php', ['id' => $defaults['course']]),

--- a/mod_form.php
+++ b/mod_form.php
@@ -93,6 +93,15 @@ class mod_equella_mod_form extends moodleform_mod {
                 }
             }
         }
+        if ($this->is_adding_equella_resource() && equella_get_config('equella_enable_lti') && empty(mod_equella_get_userfield_value())) {
+            $errparams = new stdClass();
+            $errparams->field = \mod_equella\user_field::get_equella_userfield_short_name();
+            redirect(new moodle_url('/course/view.php', ['id' => $defaults['course']]),
+                get_string('erroruserfieldempty', 'mod_equella', $errparams),
+                null,
+                \core\output\notification::NOTIFY_ERROR);
+        }
+
     }
     function display() {
         global $CFG, $USER;

--- a/popup.php
+++ b/popup.php
@@ -20,7 +20,7 @@ require_login();
 $cmid = required_param('cmid', PARAM_INT);
 
 if (equella_get_config('equella_enable_lti')) {
-    if(empty(mod_equella_get_userfield_value())){
+    if(empty(mod_equella_get_sso_userfield_value())){
         $PAGE->set_url(new moodle_url('/mod/equella/popup.php', array('cmid' => $cmid)));
         $context = context_module::instance($cmid);
         $PAGE->set_context($context);

--- a/popup.php
+++ b/popup.php
@@ -28,7 +28,7 @@ if (equella_get_config('equella_enable_lti')) {
 
         echo $OUTPUT->header();
         $errparams = new stdClass();
-        $errparams->field = \mod_equella\user_field::get_equella_userfield_short_name();
+        $errparams->field = \mod_equella\user_field::get_equella_userfield_display_name();
         echo $OUTPUT->notification(get_string('erroruserfieldempty', 'mod_equella', $errparams), 'notifyproblem');
         echo $OUTPUT->footer();
         exit;

--- a/popup.php
+++ b/popup.php
@@ -20,6 +20,19 @@ require_login();
 $cmid = required_param('cmid', PARAM_INT);
 
 if (equella_get_config('equella_enable_lti')) {
+    if(empty(mod_equella_get_userfield_value())){
+        $PAGE->set_url(new moodle_url('/mod/equella/popup.php', array('cmid' => $cmid)));
+        $context = context_module::instance($cmid);
+        $PAGE->set_context($context);
+        $PAGE->set_pagelayout('popup');
+
+        echo $OUTPUT->header();
+        $errparams = new stdClass();
+        $errparams->field = \mod_equella\user_field::get_equella_userfield_short_name();
+        echo $OUTPUT->notification(get_string('erroruserfieldempty', 'mod_equella', $errparams), 'notifyproblem');
+        echo $OUTPUT->footer();
+        exit;
+    }
     $url = new moodle_url('/mod/equella/ltilaunch.php', array('cmid' => $cmid));
 } else {
     $url = new moodle_url('/mod/equella/view.php', array('id' => $cmid,'inpopup' => true));

--- a/settings.php
+++ b/settings.php
@@ -99,6 +99,15 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_heading('equella_sso_settings', ecs('sso.heading'), ''));
 
     $userfieldoptions = \mod_equella\user_field::get_supported_fields();
+
+    // Current setting value.
+    $currentvalue = equella_get_config('equella_userfield');
+
+    // If the current setting value is a deleted custom user field, fall back to a safe default (e.g., 'username').
+    if (!array_key_exists($currentvalue, $userfieldoptions)) {
+        set_config('equella_userfield', 'username', 'equella');
+    }
+
     $settings->add(new admin_setting_configselect('equella/equella_userfield', ecs('userfield.title'), ecs('userfield.desc'), 'username', $userfieldoptions));
 
     // ///////////////////////////////////////////////////////////////////////////////

--- a/settings.php
+++ b/settings.php
@@ -54,15 +54,6 @@ if ($ADMIN->fulltree) {
 
     // ///////////////////////////////////////////////////////////////////////////////
     //
-    // SSO settings
-    //
-    $settings->add(new admin_setting_heading('equella_sso_settings', ecs('sso.heading'), ''));
-
-    $userfieldoptions = \mod_equella\user_field::get_supported_fields();
-    $settings->add(new admin_setting_configselect('equella/equella_userfield', ecs('userfield.title'), ecs('userfield.desc'), 'username', $userfieldoptions));
-
-    // ///////////////////////////////////////////////////////////////////////////////
-    //
     // LTI
     //
     $settings->add(new admin_setting_heading('equella_lti_settings', ecs('lti.heading'), ecs('lti.help')));
@@ -100,6 +91,16 @@ if ($ADMIN->fulltree) {
         $settings->add(new admin_setting_configtext("equella/equella_{$shortname}_shareid", ecs('sharedid.title'), $description, $defaultvalue, PARAM_TEXT));
         $settings->add(new admin_setting_configtext("equella/equella_{$shortname}_sharedsecret", ecs('sharedsecret.title'), $description, $defaultvalue, PARAM_TEXT));
     }
+
+    // ///////////////////////////////////////////////////////////////////////////////
+    //
+    // SSO settings
+    //
+    $settings->add(new admin_setting_heading('equella_sso_settings', ecs('sso.heading'), ''));
+
+    $userfieldoptions = \mod_equella\user_field::get_supported_fields();
+    $settings->add(new admin_setting_configselect('equella/equella_userfield', ecs('userfield.title'), ecs('userfield.desc'), 'username', $userfieldoptions));
+
     // ///////////////////////////////////////////////////////////////////////////////
     //
     // Drag and drop

--- a/view.php
+++ b/view.php
@@ -78,7 +78,12 @@ if (trim(strip_tags($equella->intro))) {
     echo format_module_intro('equella', $equella, $cm->id);
     echo $OUTPUT->box_end();
 }
-
-echo equella_embed_general($equella);
+if (equella_get_config('equella_enable_lti') && empty(mod_equella_get_userfield_value())){
+    $errparams = new stdClass();
+    $errparams->field = \mod_equella\user_field::get_equella_userfield_short_name();
+    echo $OUTPUT->notification(get_string('erroruserfieldempty', 'mod_equella', $errparams), 'notifyproblem');
+}
+else
+    echo equella_embed_general($equella);
 
 echo $OUTPUT->footer($course);

--- a/view.php
+++ b/view.php
@@ -80,7 +80,7 @@ if (trim(strip_tags($equella->intro))) {
 }
 if (equella_get_config('equella_enable_lti') && empty(mod_equella_get_userfield_value())){
     $errparams = new stdClass();
-    $errparams->field = \mod_equella\user_field::get_equella_userfield_short_name();
+    $errparams->field = \mod_equella\user_field::get_equella_userfield_display_name();
     echo $OUTPUT->notification(get_string('erroruserfieldempty', 'mod_equella', $errparams), 'notifyproblem');
 }
 else

--- a/view.php
+++ b/view.php
@@ -78,7 +78,7 @@ if (trim(strip_tags($equella->intro))) {
     echo format_module_intro('equella', $equella, $cm->id);
     echo $OUTPUT->box_end();
 }
-if (equella_get_config('equella_enable_lti') && empty(mod_equella_get_userfield_value())){
+if (equella_get_config('equella_enable_lti') && empty(mod_equella_get_sso_userfield_value())){
     $errparams = new stdClass();
     $errparams->field = \mod_equella\user_field::get_equella_userfield_display_name();
     echo $OUTPUT->notification(get_string('erroruserfieldempty', 'mod_equella', $errparams), 'notifyproblem');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/moodle-mod_openEQUELLA/issues
-->

##### Checklist

<!-- For completed items, change [ ] to [x]. For items which don't apply, please suffix with N/A -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR in build on top of the [!95](https://github.com/openequella/moodle-mod_openEQUELLA/pull/95) . 
The key enhancement/changes from the original PR are:

1.  Remove the functionality of falling back to username if the selected sso field value is empty.
2. If the selected sso field value is empty, then we don't allow the user to add or view the openEQUELLA Resource and show a message to tell user the reason and how to resolve it.
![Screenshot from 2025-03-12 14-46-27](https://github.com/user-attachments/assets/7e9d4000-3ac5-48d3-8488-9755856f8024)
![Screenshot from 2025-03-12 14-46-14](https://github.com/user-attachments/assets/30316828-379c-4a41-9116-8ed9316995f6)
![Screenshot from 2025-03-12 14-45-59](https://github.com/user-attachments/assets/4da7fb69-3103-4e73-ae7e-2abc03ea648b)


Here the Equella ID is the field which is currently set as the field for sso identification and is empty.
<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/about/governance/licensing
[commit guidelines]: https://chris.beams.io/posts/git-commit/
